### PR TITLE
feat: managed agents + dashboard activity feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ npm-debug.log*
 *.tmp
 *.temp
 idea_cards/.netlify/
+
+# Managed agent runtime files
+managed-agent/config.json
+managed-agent/monitor_config.json
+managed-agent/eval_results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Invoke when user asks to "research", "enrich", or "profile" an Atlantic Canada c
 
 ## Todoist Integration
 
-- **Env file**: Source `/Volumes/SD/Morrison Park/.env` (NOT Laurie/.env)
+- **Env file**: Source `/Users/matt/Development/Morrison Park/.env` (NOT Laurie/.env)
 - **Token var**: `TODOIST_API_TOKEN` (not TODOIST_API_KEY)
 - **API**: REST v1 at `https://api.todoist.com/api/v1/` with `Authorization: Bearer $TODOIST_API_TOKEN`
 - **Sync API v9 is deprecated** — do not use

--- a/context-map.md
+++ b/context-map.md
@@ -204,7 +204,7 @@ search_gmail_messages(query: "from:kskinner@morrisonpark.com OR to:kskinner@morr
 fireflies_search(query: "keyword:\"ken skinner\" limit:10")
 
 # GitHub — commit history
-git log --oneline --all (in /Volumes/SD/Morrison Park/)
+git log --oneline --all (in /Users/matt/Development/Morrison Park/)
 ```
 
 ### Key Dates
@@ -243,7 +243,7 @@ When starting a new session, run through this checklist:
 ## File Structure
 
 ```
-/Volumes/SD/Morrison Park/
+/Users/matt/Development/Morrison Park/
 ├── context-map.md                              ← This file (deep reference)
 ├── CLAUDE.md                                   ← Lightweight pointer
 ├── .env                                        ← Credentials (Google, Todoist, Supabase, Scraping Dog)

--- a/idea_cards/index.html
+++ b/idea_cards/index.html
@@ -189,6 +189,67 @@
       color: var(--text-primary);
     }
 
+    .multiselect {
+      position: relative;
+      width: 100%;
+    }
+
+    .multiselect-toggle {
+      width: 100%;
+      padding: 8px 12px;
+      border: 1px solid var(--border-medium);
+      border-radius: 8px;
+      font-size: 13px;
+      font-family: inherit;
+      background: var(--bg-secondary);
+      color: var(--text-primary);
+      cursor: pointer;
+      text-align: left;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .multiselect-toggle::after {
+      content: '\25BE';
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .multiselect-dropdown {
+      display: none;
+      position: absolute;
+      top: calc(100% + 4px);
+      left: 0;
+      right: 0;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border-medium);
+      border-radius: 8px;
+      padding: 4px 0;
+      z-index: 100;
+      max-height: 260px;
+      overflow-y: auto;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+    }
+
+    .multiselect-dropdown.open { display: block; }
+
+    .multiselect-option {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 12px;
+      font-size: 13px;
+      cursor: pointer;
+      color: var(--text-primary);
+    }
+
+    .multiselect-option:hover { background: var(--bg-tertiary); }
+
+    .multiselect-option input[type="checkbox"] {
+      accent-color: var(--accent-gold);
+    }
+
     .company-list {
       flex: 1;
       overflow-y: auto;
@@ -196,11 +257,11 @@
     }
 
     .company-item {
-      padding: 16px;
-      border-radius: 12px;
+      padding: 10px 12px;
+      border-radius: 10px;
       cursor: pointer;
       transition: all 0.2s ease;
-      margin-bottom: 8px;
+      margin-bottom: 4px;
       border: 1px solid transparent;
       position: relative;
     }
@@ -227,32 +288,32 @@
 
     .company-rank {
       font-family: 'JetBrains Mono', monospace;
-      font-size: 10px;
+      font-size: 9px;
       color: var(--text-muted);
-      margin-bottom: 6px;
+      margin-bottom: 4px;
     }
 
     .company-name {
       font-weight: 600;
-      font-size: 15px;
-      margin-bottom: 4px;
+      font-size: 12px;
+      margin-bottom: 3px;
       color: var(--text-primary);
     }
 
     .company-meta {
       display: flex;
       align-items: center;
-      gap: 8px;
-      font-size: 12px;
+      gap: 6px;
+      font-size: 10px;
       color: var(--text-secondary);
     }
 
     .priority-badge {
       display: inline-flex;
       align-items: center;
-      padding: 3px 8px;
-      border-radius: 4px;
-      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 8px;
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.05em;
@@ -261,6 +322,22 @@
     .priority-high { background: var(--accent-emerald-dim); color: var(--accent-emerald); }
     .priority-medium { background: var(--accent-amber-dim); color: var(--accent-amber); }
     .priority-low { background: var(--accent-rose-dim); color: var(--accent-rose); }
+
+    .badge-new {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 8px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      background: rgba(255, 120, 30, 0.15);
+      color: #ff781e;
+      animation: fade-new 0.5s ease-in;
+    }
+    @keyframes fade-new { from { opacity: 0; } to { opacity: 1; } }
 
     /* Main Content */
     .main-content {
@@ -763,6 +840,162 @@
       color: var(--text-muted);
     }
 
+    /* Activity Feed (main content) */
+    .activity-feed-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 24px;
+    }
+
+    .activity-feed-header h2 {
+      font-size: 22px;
+      font-weight: 700;
+      color: var(--text-primary);
+      margin: 0;
+    }
+
+    .activity-feed-header .activity-subtitle {
+      font-size: 13px;
+      color: var(--text-muted);
+    }
+
+    .activity-group-header {
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      padding: 12px 0 8px;
+      margin-top: 8px;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .activity-group-header.urgent { color: var(--accent-rose); }
+    .activity-group-header.notable { color: var(--accent-amber); }
+    .activity-group-header.routine { color: var(--text-muted); }
+
+    .activity-item {
+      display: flex;
+      gap: 16px;
+      padding: 16px;
+      margin: 8px 0;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: 10px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    .activity-item:hover {
+      border-color: var(--border-medium);
+      background: var(--bg-tertiary);
+    }
+
+    .activity-type-indicator {
+      width: 4px;
+      border-radius: 2px;
+      flex-shrink: 0;
+    }
+
+    .activity-type-indicator.sell_side { background: var(--accent-amber); }
+    .activity-type-indicator.buy_side { background: var(--accent-emerald); }
+    .activity-type-indicator.growth { background: var(--accent-blue); }
+    .activity-type-indicator.leadership { background: #a78bfa; }
+    .activity-type-indicator.financial { background: var(--accent-gold); }
+    .activity-type-indicator.strategic { background: #6ee7b7; }
+
+    .activity-item-body {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .activity-item-top {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 6px;
+    }
+
+    .activity-company {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text-primary);
+    }
+
+    .activity-province {
+      font-size: 11px;
+      color: var(--text-muted);
+      padding: 1px 6px;
+      background: var(--bg-tertiary);
+      border-radius: 4px;
+    }
+
+    .activity-signal-type {
+      font-size: 10px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 2px 8px;
+      border-radius: 4px;
+    }
+
+    .activity-signal-type.sell_side { background: var(--accent-amber-dim); color: var(--accent-amber); }
+    .activity-signal-type.buy_side { background: var(--accent-emerald-dim); color: var(--accent-emerald); }
+    .activity-signal-type.growth { background: var(--accent-blue-dim); color: var(--accent-blue); }
+    .activity-signal-type.leadership { background: rgba(167, 139, 250, 0.15); color: #a78bfa; }
+    .activity-signal-type.financial { background: var(--accent-gold-dim); color: var(--accent-gold); }
+    .activity-signal-type.strategic { background: rgba(110, 231, 183, 0.15); color: #6ee7b7; }
+
+    .activity-time {
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-left: auto;
+      flex-shrink: 0;
+    }
+
+    .activity-desc {
+      font-size: 13px;
+      color: var(--text-secondary);
+      line-height: 1.5;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .activity-source {
+      display: inline-block;
+      font-size: 11px;
+      color: var(--accent-blue);
+      margin-top: 6px;
+      text-decoration: none;
+    }
+
+    .activity-source:hover { text-decoration: underline; }
+
+    .activity-empty {
+      text-align: center;
+      padding: 60px 24px;
+      color: var(--text-muted);
+      font-size: 14px;
+    }
+
+    .back-to-feed {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      color: var(--text-muted);
+      cursor: pointer;
+      margin-bottom: 16px;
+      padding: 4px 0;
+      border: none;
+      background: none;
+      font-family: inherit;
+    }
+
+    .back-to-feed:hover { color: var(--text-primary); }
+
     /* Overlay for mobile */
     .sidebar-overlay {
       display: none;
@@ -774,10 +1007,123 @@
 
     .sidebar-overlay.open { display: block; }
 
+    /* Login Gate */
+    .login-gate {
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--bg-primary);
+    }
+
+    .login-gate.hidden { display: none; }
+
+    .login-box {
+      width: 340px;
+      padding: 40px 32px;
+      background: var(--bg-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: 16px;
+      text-align: center;
+    }
+
+    .login-box img {
+      height: 32px;
+      margin-bottom: 8px;
+    }
+
+    .login-box h2 {
+      font-size: 18px;
+      font-weight: 700;
+      color: var(--text-primary);
+      margin: 0 0 4px;
+    }
+
+    .login-box .login-subtitle {
+      font-size: 13px;
+      color: var(--text-muted);
+      margin-bottom: 24px;
+    }
+
+    .login-input {
+      width: 100%;
+      padding: 10px 14px;
+      border: 1px solid var(--border-medium);
+      border-radius: 8px;
+      font-size: 14px;
+      font-family: inherit;
+      background: var(--bg-secondary);
+      color: var(--text-primary);
+      margin-bottom: 12px;
+      box-sizing: border-box;
+    }
+
+    .login-input:focus {
+      outline: none;
+      border-color: var(--accent-gold);
+    }
+
+    .login-btn {
+      width: 100%;
+      padding: 10px;
+      border: none;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 600;
+      font-family: inherit;
+      background: var(--accent-gold);
+      color: #000;
+      cursor: pointer;
+      transition: opacity 0.2s;
+    }
+
+    .login-btn:hover { opacity: 0.9; }
+
+    .login-error {
+      font-size: 12px;
+      color: var(--accent-rose);
+      margin-top: 8px;
+      min-height: 16px;
+    }
+
+    /* Logout button */
+    .logout-btn {
+      border: none;
+      background: none;
+      color: var(--text-muted);
+      font-size: 11px;
+      font-family: inherit;
+      cursor: pointer;
+      padding: 4px 8px;
+      border-radius: 4px;
+      transition: all 0.2s;
+    }
+
+    .logout-btn:hover {
+      color: var(--text-primary);
+      background: var(--bg-tertiary);
+    }
+
   </style>
 </head>
 <body>
-  <div class="app">
+  <!-- Login Gate -->
+  <div class="login-gate" id="login-gate">
+    <div class="login-box">
+      <img src="MPA-Advisors-white.png" alt="Morrison Park Advisors" style="filter: brightness(0) invert(0.7);">
+      <h2>Deal Intelligence</h2>
+      <div class="login-subtitle">Enter password to continue</div>
+      <form onsubmit="return handleLogin(event)">
+        <input type="password" class="login-input" id="login-password" placeholder="Password" autofocus>
+        <button type="submit" class="login-btn">Sign In</button>
+      </form>
+      <div class="login-error" id="login-error"></div>
+    </div>
+  </div>
+
+  <div class="app" id="app" style="display:none;">
     <!-- Mobile Header -->
     <div class="mobile-header">
       <button class="menu-btn" onclick="toggleSidebar()">
@@ -809,7 +1155,10 @@
             <img src="MPA-Advisors-white.png" alt="Morrison Park Advisors">
           </div>
         </div>
-        <div class="sidebar-subtitle">Deal Intelligence</div>
+        <div class="sidebar-subtitle" style="display:flex;align-items:center;justify-content:space-between;">
+          Deal Intelligence
+          <button class="logout-btn" onclick="handleLogout()">Logout</button>
+        </div>
       </div>
 
       <!-- Filter Controls -->
@@ -834,21 +1183,29 @@
         </div>
         <div>
           <div class="filter-label">Pipeline Stage</div>
-          <select class="filter-select" id="stage-filter" onchange="applyFilters()">
-            <option value="">All Stages</option>
-            <option value="prospect">Prospect</option>
-            <option value="researching">Researching</option>
-            <option value="outreach_pending">Outreach Pending</option>
-            <option value="initial_contact_made">Initial Contact Made</option>
-            <option value="initial_discussion_complete">Initial Discussion Complete</option>
-            <option value="follow_up_pending">Follow Up Pending</option>
-            <option value="engaged">Engaged</option>
-            <option value="closed">Closed</option>
-            <option value="monitor">Monitor</option>
-            <option value="passed">Passed</option>
-            <option value="none">No Status</option>
-          </select>
+          <div class="multiselect" id="stage-multiselect">
+            <button type="button" class="multiselect-toggle" id="stage-toggle" onclick="var d=document.getElementById('stage-dropdown');d.classList.toggle('open');event.stopPropagation();">
+              <span id="stage-label">All Stages</span>
+            </button>
+            <div class="multiselect-dropdown" id="stage-dropdown">
+              <label class="multiselect-option"><input type="checkbox" value="prospect" onchange="onStageChange()"> Prospect</label>
+              <label class="multiselect-option"><input type="checkbox" value="researching" onchange="onStageChange()"> Researching</label>
+              <label class="multiselect-option"><input type="checkbox" value="outreach_pending" onchange="onStageChange()"> Outreach Pending</label>
+              <label class="multiselect-option"><input type="checkbox" value="initial_contact_made" onchange="onStageChange()"> Initial Contact Made</label>
+              <label class="multiselect-option"><input type="checkbox" value="initial_discussion_complete" onchange="onStageChange()"> Initial Discussion Complete</label>
+              <label class="multiselect-option"><input type="checkbox" value="follow_up_pending" onchange="onStageChange()"> Follow Up Pending</label>
+              <label class="multiselect-option"><input type="checkbox" value="engaged" onchange="onStageChange()"> Engaged</label>
+              <label class="multiselect-option"><input type="checkbox" value="closed" onchange="onStageChange()"> Closed</label>
+              <label class="multiselect-option"><input type="checkbox" value="monitor" onchange="onStageChange()"> Monitor</label>
+              <label class="multiselect-option"><input type="checkbox" value="passed" onchange="onStageChange()"> Passed</label>
+              <label class="multiselect-option"><input type="checkbox" value="none" onchange="onStageChange()"> No Status</label>
+            </div>
+          </div>
         </div>
+        <label style="display:flex;align-items:center;gap:8px;margin-top:8px;font-size:12px;color:var(--text-secondary);cursor:pointer;">
+          <input type="checkbox" id="new-only-filter" onchange="applyFilters()" style="accent-color:var(--accent-gold);">
+          Display new only
+        </label>
       </div>
 
       <!-- Company List -->
@@ -862,15 +1219,115 @@
 
     <!-- Main Content -->
     <main class="main-content" id="main-content">
-      <div class="empty-state" id="empty-state">
-        <h2>Select a company</h2>
-        <p>Choose a company from the sidebar to view details</p>
-      </div>
+      <!-- Activity Feed (default view) -->
+      <div id="activity-feed"></div>
+      <!-- Company Detail (shown when a company is selected) -->
       <div id="company-detail" style="display: none;"></div>
     </main>
   </div>
 
   <script>
+    // ═══════════════════════════════════════
+    // Password Gate (30-day localStorage)
+    // ═══════════════════════════════════════
+    var AUTH_HASH = 'ee82be855c462af79e18130f7fb9670aeb623b5220247967063420a0535c87e4';
+    var AUTH_KEY = 'mpa_auth';
+    var AUTH_TTL = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+    async function sha256(message) {
+      var encoder = new TextEncoder();
+      var data = encoder.encode(message);
+      var hash = await crypto.subtle.digest('SHA-256', data);
+      return Array.from(new Uint8Array(hash)).map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
+    }
+
+    function checkAuth() {
+      try {
+        var stored = JSON.parse(localStorage.getItem(AUTH_KEY));
+        if (stored && stored.hash === AUTH_HASH && Date.now() < stored.expires) {
+          showApp();
+          return;
+        }
+      } catch (e) { /* ignore */ }
+      showLogin();
+    }
+
+    function showLogin() {
+      document.getElementById('login-gate').classList.remove('hidden');
+      document.getElementById('app').style.display = 'none';
+    }
+
+    function showApp() {
+      document.getElementById('login-gate').classList.add('hidden');
+      document.getElementById('app').style.display = '';
+    }
+
+    async function handleLogin(e) {
+      e.preventDefault();
+      var password = document.getElementById('login-password').value;
+      var hash = await sha256(password);
+      if (hash === AUTH_HASH) {
+        localStorage.setItem(AUTH_KEY, JSON.stringify({ hash: AUTH_HASH, expires: Date.now() + AUTH_TTL }));
+        document.getElementById('login-error').textContent = '';
+        showApp();
+      } else {
+        document.getElementById('login-error').textContent = 'Incorrect password';
+        document.getElementById('login-password').value = '';
+        document.getElementById('login-password').focus();
+      }
+      return false;
+    }
+
+    function handleLogout() {
+      localStorage.removeItem(AUTH_KEY);
+      showLogin();
+      document.getElementById('login-password').value = '';
+      document.getElementById('login-password').focus();
+    }
+
+    // Check auth on page load
+    checkAuth();
+
+    // Seed seen state: mark all pre-existing companies/signals as seen on first visit
+    var SEEN_SEEDED_KEY = 'mpa_seen_seeded_v2';
+    if (!localStorage.getItem(SEEN_SEEDED_KEY)) {
+      // Will be populated after companies load — see loadCompanies
+      window._needsSeedSeen = true;
+    }
+
+    // ═══════════════════════════════════════
+    // Seen tracking (companies + signals)
+    // ═══════════════════════════════════════
+    var SEEN_COMPANIES_KEY = 'mpa_seen_companies';
+    var SEEN_SIGNALS_KEY = 'mpa_seen_signals';
+
+    function getSeenSet(key) {
+      try {
+        var arr = JSON.parse(localStorage.getItem(key));
+        return arr ? new Set(arr) : new Set();
+      } catch (e) { return new Set(); }
+    }
+
+    function markSeen(key, id) {
+      var seen = getSeenSet(key);
+      seen.add(id);
+      localStorage.setItem(key, JSON.stringify(Array.from(seen)));
+    }
+
+    function isSeen(key, id) {
+      return getSeenSet(key).has(id);
+    }
+
+    function markCompanySeen(companyId) {
+      markSeen(SEEN_COMPANIES_KEY, companyId);
+      // Also mark all signals for this company as seen
+      activitySignals.forEach(function(s) {
+        if (s.companies && s.companies.id === companyId) {
+          markSeen(SEEN_SIGNALS_KEY, s.id);
+        }
+      });
+    }
+
     // Initialize app once
     if (!window.appInitialized) {
       window.appInitialized = true;
@@ -904,13 +1361,34 @@
 
         if (error) throw error;
         companies = data || [];
-        restoreFilters();
-        const filtered = applyFilters();
 
-        // Auto-select first company in the filtered/sorted list
-        if (filtered.length > 0) {
-          selectCompany(filtered[0].id);
+        // Seed: mark companies created before today as seen
+        if (window._needsSeedSeen) {
+          var today = new Date().toISOString().slice(0, 10);
+          companies.forEach(function(c) {
+            if (c.created_at && c.created_at.slice(0, 10) < today) {
+              markSeen(SEEN_COMPANIES_KEY, c.id);
+            }
+          });
+          // Also seed signals
+          var thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+          var { data: sigs } = await supabase.from('signals').select('id,created_at').gte('created_at', thirtyDaysAgo);
+          if (sigs) {
+            sigs.forEach(function(s) {
+              if (s.created_at && s.created_at.slice(0, 10) < today) {
+                markSeen(SEEN_SIGNALS_KEY, s.id);
+              }
+            });
+          }
+          localStorage.setItem(SEEN_SEEDED_KEY, 'true');
+          window._needsSeedSeen = false;
         }
+
+        restoreFilters();
+        applyFilters();
+
+        // Show activity feed as default view
+        showActivityFeed();
       } catch (err) {
         console.error('Error loading companies:', err);
         document.getElementById('company-list').innerHTML = `
@@ -923,6 +1401,38 @@
     }
 
 
+    // Stage multiselect — close dropdown when clicking outside
+    document.addEventListener('click', function(e) {
+      var dropdown = document.getElementById('stage-dropdown');
+      var toggle = document.getElementById('stage-toggle');
+      if (dropdown && !dropdown.contains(e.target) && e.target !== toggle) {
+        dropdown.classList.remove('open');
+      }
+    });
+
+    function getSelectedStages() {
+      const checks = document.querySelectorAll('#stage-dropdown input[type="checkbox"]:checked');
+      return Array.from(checks).map(c => c.value);
+    }
+
+    function updateStageLabel() {
+      const selected = getSelectedStages();
+      const label = document.getElementById('stage-label');
+      if (selected.length === 0) {
+        label.textContent = 'All Stages';
+      } else if (selected.length === 1) {
+        const text = selected[0] === 'none' ? 'No Status' : selected[0].replace(/_/g, ' ');
+        label.textContent = text.charAt(0).toUpperCase() + text.slice(1);
+      } else {
+        label.textContent = selected.length + ' stages selected';
+      }
+    }
+
+    function onStageChange() {
+      updateStageLabel();
+      applyFilters();
+    }
+
     // Restore saved filter state
     function restoreFilters() {
       try {
@@ -930,18 +1440,24 @@
         if (!saved) return;
         if (saved.province) document.getElementById('province-filter').value = saved.province;
         if (saved.sortBy) document.getElementById('sort-by').value = saved.sortBy;
-        if (saved.stage) document.getElementById('stage-filter').value = saved.stage;
+        if (saved.stages && Array.isArray(saved.stages)) {
+          const checks = document.querySelectorAll('#stage-dropdown input[type="checkbox"]');
+          checks.forEach(cb => { cb.checked = saved.stages.includes(cb.value); });
+          updateStageLabel();
+        }
+        if (saved.newOnly) document.getElementById('new-only-filter').checked = true;
       } catch (e) { /* ignore */ }
     }
 
     // Apply filters
     function applyFilters() {
-      const province = document.getElementById('province-filter').value;
-      const sortBy = document.getElementById('sort-by').value;
-      const stage = document.getElementById('stage-filter').value;
+      var province = document.getElementById('province-filter').value;
+      var sortBy = document.getElementById('sort-by').value;
+      var stages = getSelectedStages();
+      var newOnly = document.getElementById('new-only-filter').checked;
 
       // Persist to localStorage
-      localStorage.setItem('mpa-filters', JSON.stringify({ province, sortBy, stage }));
+      localStorage.setItem('mpa-filters', JSON.stringify({ province, sortBy, stages, newOnly }));
 
       let filtered = [...companies];
 
@@ -950,11 +1466,17 @@
         filtered = filtered.filter(c => c.province === province);
       }
 
-      // Filter by pipeline stage
-      if (stage === 'none') {
-        filtered = filtered.filter(c => !c.pipeline_stage);
-      } else if (stage) {
-        filtered = filtered.filter(c => c.pipeline_stage === stage);
+      // Filter by pipeline stage (multiselect)
+      if (stages.length > 0) {
+        filtered = filtered.filter(c => {
+          if (stages.includes('none') && !c.pipeline_stage) return true;
+          return stages.includes(c.pipeline_stage);
+        });
+      }
+
+      // Filter to new only
+      if (newOnly) {
+        filtered = filtered.filter(c => !isSeen(SEEN_COMPANIES_KEY, c.id));
       }
 
       // Sort
@@ -973,6 +1495,149 @@
       return filtered;
     }
 
+    // ═══════════════════════════════════════
+    // Activity Feed (main content default view)
+    // ═══════════════════════════════════════
+
+    var activitySignals = [];
+
+    function showActivityFeed() {
+      document.getElementById('activity-feed').style.display = '';
+      document.getElementById('company-detail').style.display = 'none';
+      selectedCompanyId = null;
+      // Deselect sidebar items
+      document.querySelectorAll('.company-item.active').forEach(function(el) {
+        el.classList.remove('active');
+      });
+      loadActivityFeed();
+    }
+
+    async function loadActivityFeed() {
+      var feed = document.getElementById('activity-feed');
+      feed.innerHTML = '<div class="activity-empty">Loading signals...</div>';
+
+      try {
+        var thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+        var { data, error } = await supabase
+          .from('signals')
+          .select('*, companies(id, name, province, succession_composite)')
+          .gte('created_at', thirtyDaysAgo)
+          .order('created_at', { ascending: false });
+
+        if (error) throw error;
+        activitySignals = data || [];
+        renderActivityFeed(activitySignals);
+      } catch (err) {
+        feed.innerHTML = '<div class="activity-empty">Error loading signals: ' + err.message + '</div>';
+      }
+    }
+
+    function classifyUrgency(signal) {
+      var cat = (signal.signal_category || '').toLowerCase();
+      var desc = (signal.description || '').toLowerCase();
+
+      if (cat === 'health_event' || cat === 'obituary') return 'urgent';
+      if (desc.indexOf('acquired') > -1 && desc.indexOf('rumor') === -1) return 'urgent';
+      if (cat === 'pe_fund_life' || cat === 'asset_sale') return 'urgent';
+      if (desc.indexOf('receivership') > -1 || desc.indexOf('restructuring') > -1) return 'urgent';
+
+      if (signal.signal_type === 'leadership') return 'notable';
+      if (cat === 'ceo_hire' || cat === 'founder_departure' || cat === 'founder_transition') return 'notable';
+      if (cat === 'board_change' || cat === 'new_investor' || cat === 'capital_raise') return 'notable';
+      if (cat === 'legacy_signals' || cat === 'legacy') return 'notable';
+      if (cat === 'new_contract' || cat === 'expansion' || cat === 'market_expansion') return 'notable';
+      if (cat === 'merger' || cat === 'm&a_announcement') return 'notable';
+
+      return 'routine';
+    }
+
+    function timeAgo(dateStr) {
+      var diff = Date.now() - new Date(dateStr).getTime();
+      var hours = Math.floor(diff / (1000 * 60 * 60));
+      if (hours < 1) return 'just now';
+      if (hours < 24) return hours + 'h ago';
+      var days = Math.floor(hours / 24);
+      if (days === 1) return '1 day ago';
+      if (days < 7) return days + ' days ago';
+      var weeks = Math.floor(days / 7);
+      if (weeks === 1) return '1 week ago';
+      return weeks + ' weeks ago';
+    }
+
+    function renderActivityFeed(signals) {
+      var feed = document.getElementById('activity-feed');
+
+      if (!signals || signals.length === 0) {
+        feed.innerHTML = '<div class="activity-empty">No signals in the last 30 days.<br>Run the monitoring agent to scan for updates.</div>';
+        return;
+      }
+
+      var urgent = [];
+      var notable = [];
+      var routine = [];
+
+      signals.forEach(function(s) {
+        var tier = classifyUrgency(s);
+        if (tier === 'urgent') urgent.push(s);
+        else if (tier === 'notable') notable.push(s);
+        else routine.push(s);
+      });
+
+      var recentCount = signals.filter(function(s) {
+        return !isSeen(SEEN_SIGNALS_KEY, s.id);
+      }).length;
+
+      var html = '<div class="activity-feed-header">'
+        + '<div><h2>Activity Feed</h2>'
+        + '<div class="activity-subtitle">Last 30 days across all companies'
+        + (recentCount > 0 ? ' &middot; <span style="color:#ff781e;font-weight:600;">' + recentCount + ' new</span>' : '')
+        + '</div></div></div>';
+
+      if (urgent.length > 0) {
+        html += '<div class="activity-group-header urgent">Urgent (' + urgent.length + ')</div>';
+        html += urgent.map(renderActivityItem).join('');
+      }
+
+      if (notable.length > 0) {
+        html += '<div class="activity-group-header notable">Notable (' + notable.length + ')</div>';
+        html += notable.map(renderActivityItem).join('');
+      }
+
+      if (routine.length > 0) {
+        html += '<div class="activity-group-header routine">Routine (' + routine.length + ')</div>';
+        html += routine.map(renderActivityItem).join('');
+      }
+
+      feed.innerHTML = html;
+    }
+
+    function renderActivityItem(signal) {
+      var companyName = signal.companies ? signal.companies.name : 'Unknown';
+      var companyId = signal.companies ? signal.companies.id : '';
+      var province = signal.companies ? signal.companies.province : '';
+      var unseen = !isSeen(SEEN_SIGNALS_KEY, signal.id);
+      var signalType = signal.signal_type || '';
+      var category = (signal.signal_category || '').replace(/_/g, ' ');
+
+      return '<div class="activity-item" onclick="selectCompany(\'' + companyId + '\', true)">'
+        + '<div class="activity-type-indicator ' + signalType + '"></div>'
+        + '<div class="activity-item-body">'
+        + '<div class="activity-item-top">'
+        + '<span class="activity-company">' + companyName + '</span>'
+        + '<span class="activity-province">' + province + '</span>'
+        + '<span class="activity-signal-type ' + signalType + '">' + signalType.replace('_', ' ') + '</span>'
+        + (unseen ? '<span style="font-size:9px;font-weight:700;padding:2px 6px;border-radius:4px;background:rgba(255,120,30,0.15);color:#ff781e;text-transform:uppercase;">new</span>' : '')
+        + '<span class="activity-time">' + timeAgo(signal.created_at) + '</span>'
+        + '</div>'
+        + '<div class="activity-desc">' + (signal.description || category) + '</div>'
+        + (signal.source_url ? '<a class="activity-source" href="' + signal.source_url + '" target="_blank" onclick="event.stopPropagation();">View source</a>' : '')
+        + '</div></div>';
+    }
+
+    // ═══════════════════════════════════════
+    // Render company list
+    // ═══════════════════════════════════════
+
     // Render company list
     function renderCompanyList(list = companies) {
       const container = document.getElementById('company-list');
@@ -988,10 +1653,12 @@
           : company.succession_readiness === 'Medium'
             ? 'priority-medium'
             : 'priority-low';
+        const unseen = !isSeen(SEEN_COMPANIES_KEY, company.id);
 
         return `
           <div class="company-item ${company.id === selectedCompanyId ? 'active' : ''}"
                onclick="selectCompany('${company.id}')">
+            ${unseen ? '<span class="badge-new">NEW</span>' : ''}
             <div class="company-rank">#${index + 1} · ${company.province}</div>
             <div class="company-name">${company.name}</div>
             <div class="company-meta">
@@ -1005,8 +1672,9 @@
     }
 
     // Select company and show details
-    async function selectCompany(companyId) {
+    async function selectCompany(companyId, scrollToTimeline) {
       selectedCompanyId = companyId;
+      markCompanySeen(companyId);
       applyFilters();
 
       // Close sidebar on mobile
@@ -1022,7 +1690,7 @@
         supabase.from('key_people').select('*').eq('company_id', companyId),
         supabase.from('research_sources').select('*').eq('company_id', companyId),
         supabase.from('user_feedback').select('*').eq('company_id', companyId).maybeSingle(),
-        supabase.from('signals').select('*').eq('company_id', companyId).order('signal_date', { ascending: false }),
+        supabase.from('signals').select('*').eq('company_id', companyId).order('created_at', { ascending: false }),
         supabase.from('connections').select('*').eq('company_id', companyId),
         supabase.from('pipeline').select('*').eq('company_id', companyId).maybeSingle(),
         supabase.from('potential_acquirers').select('*').eq('company_id', companyId),
@@ -1038,9 +1706,18 @@
       const acquirers = acquirersRes.data || [];
       const investors = investorsRes.data || [];
 
-      document.getElementById('empty-state').style.display = 'none';
+      document.getElementById('activity-feed').style.display = 'none';
       document.getElementById('company-detail').style.display = 'block';
-      document.getElementById('company-detail').innerHTML = renderCompanyDetail(company, people, sources, feedback, signals, connections, pipeline, acquirers, investors);
+      document.getElementById('company-detail').innerHTML =
+        '<button class="back-to-feed" onclick="showActivityFeed()">&larr; Back to Activity Feed</button>'
+        + renderCompanyDetail(company, people, sources, feedback, signals, connections, pipeline, acquirers, investors);
+
+      if (scrollToTimeline) {
+        var timeline = document.getElementById('activity-timeline');
+        if (timeline) {
+          setTimeout(function() { timeline.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 100);
+        }
+      }
     }
 
     // Render company detail
@@ -1124,6 +1801,47 @@
             </div>
           </div>
         </div>
+
+        <!-- Activity Timeline -->
+        ${signals.length > 0 ? `
+        <div class="section-grid" id="activity-timeline">
+          <div class="section" style="grid-column: 1 / -1;">
+            <div class="section-header">
+              <span class="section-title">Activity Timeline (${signals.length})</span>
+            </div>
+            <div style="display: flex; flex-direction: column; gap: 8px;">
+              ${signals.map(function(signal) {
+                var signalType = signal.signal_type || '';
+                var typeColor = signalType === 'sell_side' ? 'var(--accent-amber)'
+                  : signalType === 'buy_side' ? 'var(--accent-emerald)'
+                  : signalType === 'leadership' ? '#a78bfa'
+                  : signalType === 'financial' ? 'var(--accent-gold)'
+                  : signalType === 'strategic' ? '#6ee7b7'
+                  : 'var(--accent-blue)';
+                var typeBg = signalType === 'sell_side' ? 'var(--accent-amber-dim)'
+                  : signalType === 'buy_side' ? 'var(--accent-emerald-dim)'
+                  : signalType === 'leadership' ? 'rgba(167,139,250,0.15)'
+                  : signalType === 'financial' ? 'var(--accent-gold-dim)'
+                  : signalType === 'strategic' ? 'rgba(110,231,183,0.15)'
+                  : 'var(--accent-blue-dim)';
+                var unseenSignal = !isSeen(SEEN_SIGNALS_KEY, signal.id);
+                var ago = timeAgo(signal.created_at);
+                return '<div style="display:flex;gap:12px;padding:12px;background:var(--bg-tertiary);border-radius:10px;border-left:3px solid ' + typeColor + ';">'
+                  + '<div style="flex:1;">'
+                  + '<div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">'
+                  + '<span class="source-type" style="background:' + typeBg + ';color:' + typeColor + ';">' + signalType.replace('_',' ') + '</span>'
+                  + '<span style="font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:0.04em;color:var(--text-muted);">' + (signal.signal_category || '').replace(/_/g,' ') + '</span>'
+                  + (unseenSignal ? '<span style="font-size:8px;font-weight:700;padding:2px 6px;border-radius:3px;background:rgba(255,120,30,0.15);color:#ff781e;text-transform:uppercase;">new</span>' : '')
+                  + '<span style="font-size:11px;color:var(--text-muted);margin-left:auto;">' + ago + '</span>'
+                  + '</div>'
+                  + '<div style="font-size:13px;color:var(--text-secondary);line-height:1.5;">' + (signal.description || '') + '</div>'
+                  + (signal.source_url ? '<a href="' + signal.source_url + '" target="_blank" class="source-link" style="font-size:11px;margin-top:6px;display:inline-block;">View Source</a>' : '')
+                  + '</div></div>';
+              }).join('')}
+            </div>
+          </div>
+        </div>
+        ` : ''}
 
         <!-- Company Profile (markdown narrative) -->
         ${company.markdown_content && company.markdown_content.length > 100 ? `
@@ -1240,30 +1958,6 @@
                   </div>
                 </div>`;
               }).join('')}
-            </div>
-          </div>
-        </div>
-        ` : ''}
-
-        <!-- Transaction Signals -->
-        ${signals.length > 0 ? `
-        <div class="section-grid">
-          <div class="section" style="grid-column: 1 / -1;">
-            <div class="section-header">
-              <span class="section-title">Transaction Signals (${signals.length})</span>
-            </div>
-            <div class="signals-list" style="display: flex; flex-direction: column; gap: 12px;">
-              ${signals.map(signal => `
-                <div class="signal-item" style="padding: 12px; background: var(--bg-tertiary); border-radius: 10px; border-left: 3px solid ${signal.signal_type === 'sell_side' ? 'var(--accent-amber)' : signal.signal_type === 'buy_side' ? 'var(--accent-emerald)' : 'var(--accent-blue)'};">
-                  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px;">
-                    <span class="source-type" style="background: ${signal.signal_type === 'sell_side' ? 'var(--accent-amber-dim)' : signal.signal_type === 'buy_side' ? 'var(--accent-emerald-dim)' : 'var(--accent-blue-dim)'}; color: ${signal.signal_type === 'sell_side' ? 'var(--accent-amber)' : signal.signal_type === 'buy_side' ? 'var(--accent-emerald)' : 'var(--accent-blue)'};">${signal.signal_type?.replace('_', ' ')}</span>
-                    <span style="font-size: 11px; color: var(--text-muted);">${signal.signal_date ? new Date(signal.signal_date).toLocaleDateString() : ''}</span>
-                  </div>
-                  <div style="font-size: 13px; font-weight: 500; margin-bottom: 4px;">${signal.signal_category?.replace('_', ' ')}</div>
-                  <div style="font-size: 13px; color: var(--text-secondary);">${signal.description}</div>
-                  ${signal.source_url ? `<a href="${signal.source_url}" target="_blank" class="source-link" style="font-size: 11px; margin-top: 6px; display: inline-block;">View Source</a>` : ''}
-                </div>
-              `).join('')}
             </div>
           </div>
         </div>

--- a/log.md
+++ b/log.md
@@ -5,6 +5,53 @@
 
 ---
 
+## March 2026
+
+### 2026-03-29 — Session: Ken email recap and relationship status check
+
+> Reviewed and summarized Ken Skinner's last 5 emails chronologically (March 9–24) to re-establish context on the relationship state and outstanding threads.
+
+- **Type**: session
+- **Discovered**:
+  - Ken's March 9 NFLD feedback proposed three engines: (1) refine current search, (2) real-time monitoring/alerts, (3) CRM ideation/prediction layer
+  - Ken asked March 10 about switching from ChatGPT to Claude for Morrison Park's work
+  - Ken forwarded an AI cold outreach email March 12, impressed by quality — "this is relevant to what we are doing"
+  - Ken's March 24 reply: back from Spring Break, finds Claude comparison helpful, believes AI stronger on words than numbers, subscribes to Bloomberg/S&P Capital IQ/Pitchbook, onboarding MadeMarket CRM, wants to connect in Halifax
+- **Sources**: Gmail search `from:kskinner@morrisonpark.com` → 5 messages (19cd5063db73ea07, 19cd89553e61fc23, 19ce1f952a0bc566, 19ce2137b2e58fad, 19d1d56796da26f9)
+- **Next**: Reply to Ken's March 24 email — acknowledge AI/numbers insight, note MadeMarket integration potential, lock down Halifax visit date
+
+---
+
+### 2026-03-15 — Session: Epic #20 complete, Gen 1 re-enrichment, email to Ken
+
+> Closed all 4 phases of Epic #20 (Ken's NFLD trip feedback). Shipped pipeline stages, entity matching, dashboard UI enhancements, re-enriched all 18 Gen 1 companies, added markdown rendering, and emailed Ken with a full update and call request.
+
+- **Type**: session
+- **Created**:
+  - PR [#27](https://github.com/MattVOLTA/morrison_park/pull/27) — dashboard UI enhancements (company narrative, succession evidence, sources placeholder)
+  - 54 key_people records + 192 research_sources records across 18 Gen 1 companies → Supabase
+  - 7 new transaction signals (BA Richard acquired, Elanco sold to Merck, ICPEI acquired by Desjardins, Northumberland MBO, Site 20/20 growth investment, MacLeod Lorway/Cal LeGrow merger, City Wide/Telus acquisition)
+  - Email to Ken: "Dashboard updates + let's talk about the three engines" → Gmail 19cf39b57da57cd4
+  - Todoist task: "Waiting for reply: Ken Skinner" with waiting-reply label
+- **Modified**:
+  - `idea_cards/index.html` — renderMarkdown() function converts raw markdown to styled HTML in Company Profile section
+  - `idea_cards/index.html` — succession scorecard shows owner age, tenure years, next-gen names alongside scores
+  - `idea_cards/index.html` — research sources section always renders with placeholder for empty companies
+- **Resolved**:
+  - Epic #20 closed (all 4 phases: #21 pipeline/revenue, #22 entity matching, #23 UI enhancements, #24 re-enrichment)
+  - Phase 3 browser-verified in Chrome: company narrative, succession evidence, and sources all rendering correctly
+  - Markdown rendering fixed (was showing raw `##` and `**` syntax)
+- **Discovered**:
+  - Phase 4 enrichment uncovered several post-transaction companies: Elanco ($1.75B CAD to Merck), ICPEI (Desjardins), BA Richard (Champlain Seafood), City Wide (Telus/Altima)
+  - All 36 companies now have 10+ research sources (was 0 for 18 Gen 1 companies)
+- **Sources**: GitHub PRs #25/#27, Supabase MCP, Gmail (Google Workspace MCP), Chrome browser tools
+- **Next**:
+  - [ ] Call with Ken to discuss three engines (search refinement, real-time monitoring, CRM ideation)
+  - [ ] Confidence ratings with source info behind revenue/employee estimates
+  - [ ] Full company address + contact info for key person (deferred to Amberly)
+
+---
+
 ## February 2026
 
 ### 2026-02-27 — Session: Dashboard UX upgrades, one-pager template, Ken call follow-up

--- a/managed-agent/README.md
+++ b/managed-agent/README.md
@@ -1,0 +1,75 @@
+# MPA Province Prospector — Managed Agent
+
+Anthropic Managed Agent that discovers mid-market companies matching Morrison Park Advisors' Ideal Customer Profile in Atlantic Canada provinces.
+
+## Setup
+
+```bash
+cd managed-agent
+pip install -r requirements.txt
+```
+
+Ensure `.env` in the project root contains:
+- `MPA_ANTHROPIC_API_KEY` — Anthropic API key for managed agents
+- `SCRAPING_DOG_API_KEY` — ScrapingDog API key for LinkedIn scraping
+
+## Deploy
+
+```bash
+python deploy.py
+```
+
+Creates the agent, environment, and uploads reference files. Saves all IDs to `config.json`.
+
+## Run a Session
+
+```bash
+python run_session.py NB    # Prospect in New Brunswick
+python run_session.py NS    # Prospect in Nova Scotia
+python run_session.py PEI   # Prospect in PEI
+python run_session.py NL    # Prospect in Newfoundland & Labrador
+```
+
+## Evaluate
+
+Run the agent against a province with existing baseline data and compare quality:
+
+```bash
+python eval.py NB              # Full eval (run agent + score)
+python eval.py NB --skip-run   # Score only (compare existing data)
+```
+
+Reports are saved to `eval_results/`.
+
+## Eval Metrics
+
+| Metric | Target |
+|--------|--------|
+| Discovery rate (% of baseline found) | >= 70% |
+| Revenue accuracy (within 30%) | >= 80% |
+| Ownership type match | >= 90% |
+| Industry classification match | >= 85% |
+| Succession scores (within +/-1) | >= 75% |
+| Sources per company | >= 5 |
+
+## Iteration Workflow
+
+1. Run eval: `python eval.py NB`
+2. Review scorecard — identify weak dimensions
+3. Edit system prompt in `deploy.py`
+4. Update agent: `python deploy.py --update`
+5. Re-run eval until all metrics pass
+6. Validate on remaining provinces (PEI, NL, NS)
+
+## Architecture
+
+- **Model:** Claude Sonnet 4.6
+- **Tools:** Built-in agent toolset (bash, web_search, web_fetch, read, write, glob, grep)
+- **Secrets:** Mounted credentials file (Supabase + ScrapingDog keys)
+- **Output:** Directly to Supabase database
+- **No custom tools** — agent uses bash + curl for all API calls
+
+## Cost Tracking
+
+All API calls use the dedicated `MPA_ANTHROPIC_API_KEY` for cost isolation.
+Estimated cost per session: $0.50–$1.50 (Sonnet).

--- a/managed-agent/deploy.py
+++ b/managed-agent/deploy.py
@@ -1,0 +1,462 @@
+"""
+MPA Province Prospector — Deployment Script
+
+Creates the managed agent, environment, vault, and uploads reference files.
+Saves all IDs to config.json for use by run_session.py and eval.py.
+
+Usage:
+    python deploy.py          # Full deploy (create everything)
+    python deploy.py --update # Update agent system prompt only
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from anthropic import Anthropic
+from dotenv import load_dotenv
+
+# Load credentials from project .env
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+ANTHROPIC_API_KEY = os.environ["MPA_ANTHROPIC_API_KEY"]
+SUPABASE_URL = "https://vuuoukfcbucgsqnnsaii.supabase.co"
+SUPABASE_ANON_KEY = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ1dW91a2ZjYnVjZ3Nxbm5zYWlpIiwi"
+    "cm9sZSI6ImFub24iLCJpYXQiOjE3NjQ4OTU4MTgsImV4cCI6MjA4MDQ3MTgxOH0."
+    "L9xpsTOwSpLvY7OdVvsd74oGS6ubVOJxtNCZSiXdjQY"
+)
+SCRAPINGDOG_API_KEY = os.environ["SCRAPING_DOG_API_KEY"]
+
+CONFIG_PATH = Path(__file__).parent / "config.json"
+
+client = Anthropic(api_key=ANTHROPIC_API_KEY)
+
+
+SYSTEM_PROMPT = r"""You are the MPA Province Prospector, an autonomous M&A deal intelligence agent for Morrison Park Advisors (MPA).
+
+MISSION: Discover mid-market companies in a specified Atlantic Canada province that match MPA's Ideal Customer Profile. For each company, research it thoroughly, score it against the ICP, enrich key people with LinkedIn data, and save all findings to the Supabase database. Skip any company already in the database.
+
+AUTONOMY MANDATE:
+- Execute ALL tasks immediately without asking permission
+- NEVER say "I would need to..." or "Should I..." — just do it
+- If a search returns no results, try different queries automatically
+- Complete the full mission and report findings at the end
+
+CRITICAL RULES:
+1. EVERY data point MUST have a source URL — non-negotiable for M&A credibility
+2. Check existing companies in the database FIRST to avoid duplicates
+3. Rate confidence honestly: high (primary source), medium (secondary), low (inference)
+4. Focus on mid-market companies ($10M-$500M revenue)
+5. Note all information gaps explicitly
+
+═══════════════════════════════════════════════
+SETUP — Run at the start of every session
+═══════════════════════════════════════════════
+
+Export your credentials immediately:
+```bash
+export SUPABASE_URL="__SUPABASE_URL__"
+export SUPABASE_KEY="__SUPABASE_KEY__"
+export SCRAPINGDOG_API_KEY="__SCRAPINGDOG_API_KEY__"
+```
+
+These are pre-configured. Do NOT ask for credentials — just export and use them.
+
+═══════════════════════════════════════════════
+WORKFLOW
+═══════════════════════════════════════════════
+
+1. EXPORT CREDENTIALS (run the export commands above)
+
+2. GET EXISTING COMPANIES for the target province:
+```bash
+curl -s "${SUPABASE_URL}/rest/v1/companies?province=eq.${PROVINCE}&select=name,id,industry,revenue_estimate" \
+  -H "apikey: ${SUPABASE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_KEY}"
+```
+Save this list — you will check every candidate against it.
+
+3. SEARCH FOR COMPANIES matching ICP criteria. Use web_search with queries like:
+   - "${province} largest private companies"
+   - "${province} founder owned business succession"
+   - "${province} family business manufacturing"
+   - "${province} mid-market company acquisition"
+   - "top employers ${province} private"
+   - "${province} business awards fastest growing"
+   - Sector-specific: "${province} energy company private", "${province} construction company owner"
+
+4. FOR EACH CANDIDATE COMPANY:
+   a. DEDUP CHECK: Compare name against existing companies list (case-insensitive, substring match). SKIP if already exists.
+   b. QUALIFY: Check must-haves from ICP. Revenue >$10M? Atlantic Canada? Private? DISQUALIFY if missing.
+   c. RESEARCH: Use web_search + web_fetch to gather:
+      - Company fundamentals (revenue, employees, products, history)
+      - Ownership structure (who owns it, family/founder/PE)
+      - Key people (owners, executives, board members)
+      - Recent activity (news, deals, expansions, awards)
+      - Competitive position
+   d. SCORE ICP TIER:
+      - Tier 1: $30M-$150M revenue, primary sector, founder-owned 15+yr, owner 58+
+      - Tier 2: $15M-$30M or $150M-$300M, secondary sector, family/PE
+      - Tier 3: $10M-$15M or $300M+, adjacent sector
+   e. CALCULATE SUCCESSION SCORECARD (1-5 each):
+      - Owner Age: 1 (<55), 2 (55-60), 3 (60-65), 4 (65-72), 5 (>72)
+      - Tenure: 1 (<10yr), 2 (10-15yr), 3 (15-25yr), 4 (25-35yr), 5 (>35yr)
+      - Next-Gen Clarity: 1 (clear successor), 3 (unclear), 5 (no successor)
+      - Legacy Signals: 1 (none), 3 (some philanthropy), 5 (strong legacy focus)
+      - Activity Trajectory: 1 (active growth), 3 (steady), 5 (slowing/divesting)
+   f. FIND AND SAVE AT LEAST 3 KEY PEOPLE per company:
+      - Owner/CEO, CFO, COO/VP Operations, board members
+      - For each: name, title, estimated age, tenure, ownership %, LinkedIn URL
+      - MINIMUM 3 people per company — search harder if you only find 1-2
+      - Try: company website "team"/"about"/"leadership", LinkedIn company page, news articles with executive names
+   g. SCRAPE LINKEDIN for key people (see ScrapingDog section below)
+   h. SAVE TO DATABASE (see Supabase section below)
+   i. SAVE AT LEAST 5 RESEARCH SOURCES per company (company website, news articles, LinkedIn, industry reports, government filings). Each source must have a URL.
+
+5. REPORT SUMMARY when done:
+   - Total companies scanned vs. saved
+   - Companies by ICP tier
+   - Top succession-ready companies (highest composite scores)
+   - Notable findings or patterns
+   - Companies that were disqualified and why
+
+═══════════════════════════════════════════════
+SUPABASE REST API REFERENCE
+═══════════════════════════════════════════════
+
+Base URL: ${SUPABASE_URL}/rest/v1
+Headers (always include both):
+  -H "apikey: ${SUPABASE_KEY}"
+  -H "Authorization: Bearer ${SUPABASE_KEY}"
+
+### Read companies
+```bash
+curl -s "${SUPABASE_URL}/rest/v1/companies?province=eq.NB&select=name,id" \
+  -H "apikey: ${SUPABASE_KEY}" -H "Authorization: Bearer ${SUPABASE_KEY}"
+```
+
+### Upsert company (insert or update by name)
+```bash
+curl -s -X POST "${SUPABASE_URL}/rest/v1/companies" \
+  -H "apikey: ${SUPABASE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation,resolution=merge-duplicates" \
+  -d '{
+    "name": "Company Name",
+    "location": "City",
+    "province": "NB",
+    "industry": "Manufacturing",
+    "founded_year": 1985,
+    "website": "https://example.com",
+    "ownership_type": "founder-owned",
+    "revenue_estimate": 45,
+    "employee_count": 200,
+    "score_owner_age": 4,
+    "score_tenure": 5,
+    "score_nextgen_clarity": 4,
+    "score_legacy_signals": 3,
+    "score_activity_trajectory": 3,
+    "succession_composite": 19,
+    "succession_readiness": "High",
+    "confidence": "medium"
+  }'
+```
+NOTE: revenue_estimate is in MILLIONS CAD (45 = $45M, NOT 45000000).
+NOTE: succession_composite = sum of 5 scores. Readiness: 5-10=Low, 11-15=Medium, 16-20=High, 21-25=Very High.
+NOTE: ownership_type must be one of: founder-owned, family-held, employee-owned, pe-backed, public, other
+
+### Insert key person
+```bash
+curl -s -X POST "${SUPABASE_URL}/rest/v1/key_people" \
+  -H "apikey: ${SUPABASE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{
+    "company_id": "uuid-from-company-insert",
+    "name": "John Smith",
+    "title": "CEO & Founder",
+    "role": "owner",
+    "ownership_percentage": 100,
+    "age_estimate": 67,
+    "tenure_years": 35,
+    "linkedin_url": "https://linkedin.com/in/johnsmith",
+    "source_url": "https://source.com/article"
+  }'
+```
+NOTE: role must be one of: owner, executive, board, other
+
+### Insert signal
+```bash
+curl -s -X POST "${SUPABASE_URL}/rest/v1/signals" \
+  -H "apikey: ${SUPABASE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{
+    "company_id": "uuid",
+    "signal_type": "sell_side",
+    "signal_category": "owner_age",
+    "description": "Founder is 67 years old with 35 years at helm",
+    "source_url": "https://source.com",
+    "confidence": "medium"
+  }'
+```
+NOTE: signal_type must be one of: sell_side, buy_side, growth, leadership, financial, strategic
+
+### Insert research source
+```bash
+curl -s -X POST "${SUPABASE_URL}/rest/v1/research_sources" \
+  -H "apikey: ${SUPABASE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{
+    "company_id": "uuid",
+    "source_name": "Chronicle Herald article",
+    "source_url": "https://thechronicleherald.ca/article",
+    "source_type": "news",
+    "data_points": ["revenue estimate", "employee count"],
+    "confidence": "medium"
+  }'
+```
+NOTE: source_type must be one of: company_website, press_release, news, linkedin, industry_report, government_filing, other
+
+### Upsert pipeline entry
+```bash
+curl -s -X POST "${SUPABASE_URL}/rest/v1/pipeline" \
+  -H "apikey: ${SUPABASE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation,resolution=merge-duplicates" \
+  -d '{
+    "company_id": "uuid",
+    "stage": "prospect",
+    "priority": 4,
+    "client_type": "sell_side",
+    "next_action": "Deep research and LinkedIn enrichment",
+    "notes": "Tier 1 ICP fit. Owner 67, no clear successor."
+  }'
+```
+NOTE: stage must be one of: prospect, researching, outreach_pending, initial_contact_made, initial_discussion_complete, follow_up_pending, engaged, closed, monitor, passed
+NOTE: client_type must be one of: sell_side, buy_side, growth_capital
+
+### Insert potential acquirer
+```bash
+curl -s -X POST "${SUPABASE_URL}/rest/v1/potential_acquirers" \
+  -H "apikey: ${SUPABASE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{
+    "company_id": "uuid",
+    "acquirer_name": "Strategic Buyer Inc",
+    "acquirer_type": "strategic",
+    "rationale": "Adjacent sector, geographic expansion play",
+    "source_url": "https://source.com"
+  }'
+```
+
+═══════════════════════════════════════════════
+SCRAPINGDOG LINKEDIN API
+═══════════════════════════════════════════════
+
+### Scrape a LinkedIn profile
+```bash
+curl -s "https://api.scrapingdog.com/linkedin?api_key=${SCRAPINGDOG_API_KEY}&type=profile&linkId=PROFILE_ID&premium=true"
+```
+- Extract PROFILE_ID from LinkedIn URL: https://linkedin.com/in/johnsmith → johnsmith
+- Always use premium=true for reliability
+- Cost: 100 credits per profile (premium)
+- Budget: 3-5 profiles per company, max 10 per session
+- Parse the JSON response for: fullName, headline, location, about, experience[], education[]
+
+### Handle errors
+- HTTP 202: Not ready yet. Wait 2 minutes, retry (not charged)
+- HTTP 400/404: Profile not found. Skip and note in research.
+- JSON parsing: LinkedIn bios may contain control characters. Clean with:
+```bash
+curl -s "URL" | python3 -c "
+import sys, json, re
+raw = sys.stdin.buffer.read()
+cleaned = re.sub(rb'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', b'', raw)
+d = json.loads(cleaned)
+if isinstance(d, list): d = d[0]
+print(json.dumps(d, indent=2))
+"
+```
+
+### Find LinkedIn profiles
+Use web_search to find LinkedIn URLs for key people:
+- "site:linkedin.com/in/ {person_name} {company_name}"
+- Extract the profile ID from the URL
+
+### What to extract from LinkedIn
+For each key person, save to key_people table:
+- linkedin_url
+- linkedin_headline (from headline field)
+- linkedin_about (from about field, first 500 chars)
+- Age estimate (from graduation dates or career start)
+- Tenure (from experience dates at current company)
+
+═══════════════════════════════════════════════
+ATLANTIC CANADA CONTEXT
+═══════════════════════════════════════════════
+
+- Smaller market where relationships matter significantly
+- Many family-held businesses spanning generations
+- Strong regional identity
+- Seasonal industries (fishing, tourism) have different cycles
+- Government connections often relevant (ACOA funding, university ties)
+- Key cities: Halifax (NS), Moncton/Saint John/Fredericton (NB), Charlottetown (PEI), St. John's (NL)
+
+═══════════════════════════════════════════════
+IDEAL CUSTOMER PROFILE (ICP)
+═══════════════════════════════════════════════
+
+## Deal Size Sweet Spot
+| Range | Transaction Value | Typical Revenue |
+|-------|-------------------|-----------------|
+| Core | $30M - $150M | $20M - $100M |
+| Stretch | $150M - $500M | $100M - $300M |
+
+## Sector Expertise
+Primary: Energy, Mining, Healthcare, Financial Services, Industrials
+Secondary: Manufacturing, Professional Services, Construction, Technology, Telecom
+Gap (opportunity): Seafood/Aquaculture, Tourism/Hospitality, Agriculture
+
+## Must-Haves (Disqualify if Missing)
+- Revenue >$10M
+- Profitable or clear path to profitability
+- Located in Atlantic Canada (NS, NB, PEI, NL)
+- Private or small-cap public (<$500M market cap)
+- Decision-maker accessible
+
+## ICP Tiers
+Tier 1 (Ideal): $30M-$150M revenue, primary sector, founder-owned 15+yr, owner 58+, active succession trigger
+Tier 2 (Good): $15M-$30M or $150M-$300M, secondary sector, family-held or PE-backed
+Tier 3 (Opportunistic): $10M-$15M or $300M+, adjacent sectors
+
+## High-Priority Triggers
+Owner age 60+, no clear successor, health event, partner dispute, PE fund end-of-life
+
+## Medium-Priority Triggers
+Industry consolidation, capital needs, regulatory change, key customer concentration >30%
+
+## Succession Scorecard (1-5)
+Owner Age: 1(<55) 2(55-60) 3(60-65) 4(65-72) 5(>72)
+Tenure: 1(<10yr) 2(10-15yr) 3(15-25yr) 4(25-35yr) 5(>35yr)
+Next-Gen Clarity: 1(clear successor) 3(unclear) 5(no successor)
+Legacy Signals: 1(none) 3(some philanthropy) 5(strong legacy focus)
+Activity Trajectory: 1(active growth) 3(steady) 5(slowing/divesting)
+Readiness: 5-10=Low, 11-15=Medium, 16-20=High, 21-25=Very High
+
+## Disqualifiers
+Revenue <$10M, distressed with no path, owner not interested, already engaged with competitor advisor, industry MPA has no expertise in
+"""
+
+
+def build_system_prompt():
+    """Substitute real credentials into the system prompt template."""
+    return (
+        SYSTEM_PROMPT
+        .replace("__SUPABASE_URL__", SUPABASE_URL)
+        .replace("__SUPABASE_KEY__", SUPABASE_ANON_KEY)
+        .replace("__SCRAPINGDOG_API_KEY__", SCRAPINGDOG_API_KEY)
+    )
+
+
+def load_config() -> dict:
+    if CONFIG_PATH.exists():
+        return json.loads(CONFIG_PATH.read_text())
+    return {}
+
+
+def save_config(config: dict):
+    CONFIG_PATH.write_text(json.dumps(config, indent=2))
+    print(f"Config saved to {CONFIG_PATH}")
+
+
+def deploy():
+    print("=== MPA Province Prospector — Deployment ===\n")
+    config = load_config()
+
+    # 1. Create environment
+    if "environment_id" not in config:
+        print("Creating environment...")
+        env = client.beta.environments.create(
+            name="mpa-prospector-env",
+            config={
+                "type": "cloud",
+                "packages": {"pip": ["requests"]},
+                "networking": {"type": "unrestricted"},
+            },
+        )
+        config["environment_id"] = env.id
+        print(f"  Environment: {env.id}")
+    else:
+        print(f"  Environment exists: {config['environment_id']}")
+
+    # 2. Create agent (credentials embedded in system prompt)
+    system = build_system_prompt()
+    if "agent_id" not in config:
+        print("Creating agent...")
+        agent = client.beta.agents.create(
+            name="MPA Province Prospector",
+            model="claude-sonnet-4-6",
+            description=(
+                "Discovers mid-market companies matching Morrison Park Advisors' "
+                "Ideal Customer Profile in Atlantic Canada provinces. Researches, "
+                "scores, enriches with LinkedIn data, and saves to Supabase."
+            ),
+            system=system,
+            tools=[
+                {
+                    "type": "agent_toolset_20260401",
+                    "default_config": {"enabled": True},
+                }
+            ],
+        )
+        config["agent_id"] = agent.id
+        config["agent_version"] = agent.version
+        print(f"  Agent: {agent.id} (v{agent.version})")
+    else:
+        print(f"  Agent exists: {config['agent_id']}")
+
+    save_config(config)
+
+    print("\n=== Deployment Complete ===")
+    print(f"  Agent ID:       {config['agent_id']}")
+    print(f"  Environment ID: {config['environment_id']}")
+    print(f"\nRun a session:  python run_session.py NB")
+    print(f"Run eval:       python eval.py NB")
+
+
+def update_agent():
+    """Update the agent's system prompt without recreating everything."""
+    config = load_config()
+    if "agent_id" not in config:
+        print("No agent found. Run deploy first.")
+        sys.exit(1)
+
+    print("Updating agent system prompt...")
+    system = build_system_prompt()
+    agent = client.beta.agents.update(
+        agent_id=config["agent_id"],
+        version=config["agent_version"],
+        system=system,
+    )
+    config["agent_version"] = agent.version
+    save_config(config)
+    print(f"  Agent updated: {agent.id} (v{agent.version})")
+
+
+if __name__ == "__main__":
+    if "--update" in sys.argv:
+        update_agent()
+    else:
+        deploy()

--- a/managed-agent/eval.py
+++ b/managed-agent/eval.py
@@ -1,0 +1,373 @@
+"""
+MPA Province Prospector — Evaluation Script
+
+Two modes:
+  --prospecting (default): Agent finds new companies. Scores quality/novelty.
+  --rediscovery:           Agent profiles known companies. Scores accuracy.
+
+Usage:
+    python eval.py NB                    # Prospecting eval (default)
+    python eval.py NB --rediscovery      # Rediscovery eval
+    python eval.py NB --skip-run         # Score existing data only
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+from anthropic import Anthropic
+from dotenv import load_dotenv
+
+from scoring import (
+    RediscoveryScorecard,
+    ProspectingScorecard,
+    find_best_match,
+    score_company,
+    score_prospect,
+)
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+ANTHROPIC_API_KEY = os.environ["MPA_ANTHROPIC_API_KEY"]
+SUPABASE_URL = "https://vuuoukfcbucgsqnnsaii.supabase.co"
+SUPABASE_ANON_KEY = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ1dW91a2ZjYnVjZ3Nxbm5zYWlpIiwi"
+    "cm9sZSI6ImFub24iLCJpYXQiOjE3NjQ4OTU4MTgsImV4cCI6MjA4MDQ3MTgxOH0."
+    "L9xpsTOwSpLvY7OdVvsd74oGS6ubVOJxtNCZSiXdjQY"
+)
+
+CONFIG_PATH = Path(__file__).parent / "config.json"
+RESULTS_DIR = Path(__file__).parent / "eval_results"
+
+PROVINCE_NAMES = {
+    "NB": "New Brunswick",
+    "NS": "Nova Scotia",
+    "PEI": "Prince Edward Island",
+    "NL": "Newfoundland and Labrador",
+}
+
+client = Anthropic(api_key=ANTHROPIC_API_KEY)
+HEADERS = {
+    "apikey": SUPABASE_ANON_KEY,
+    "Authorization": "Bearer %s" % SUPABASE_ANON_KEY,
+}
+
+
+def load_config():
+    if not CONFIG_PATH.exists():
+        print("No config.json found. Run deploy.py first.")
+        sys.exit(1)
+    return json.loads(CONFIG_PATH.read_text())
+
+
+def supabase_get(table, params=None):
+    url = "%s/rest/v1/%s" % (SUPABASE_URL, table)
+    resp = requests.get(url, headers=HEADERS, params=params or {})
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_baseline(province):
+    """Pull all baseline data for a province."""
+    companies = supabase_get("companies", {"province": "eq.%s" % province, "select": "*"})
+    company_ids = [c["id"] for c in companies]
+
+    key_people = {}
+    sources = {}
+    signals = {}
+    pipeline = {}
+    for cid in company_ids:
+        key_people[cid] = supabase_get("key_people", {"company_id": "eq.%s" % cid, "select": "*"})
+        sources[cid] = supabase_get("research_sources", {"company_id": "eq.%s" % cid, "select": "*"})
+        signals[cid] = supabase_get("signals", {"company_id": "eq.%s" % cid, "select": "*"})
+        pipeline[cid] = supabase_get("pipeline", {"company_id": "eq.%s" % cid, "select": "*"})
+
+    return {
+        "companies": companies,
+        "key_people": key_people,
+        "sources": sources,
+        "signals": signals,
+        "pipeline": pipeline,
+    }
+
+
+def get_agent_results(province, since):
+    """Pull companies created/updated after a timestamp."""
+    companies = supabase_get("companies", {
+        "province": "eq.%s" % province,
+        "updated_at": "gte.%s" % since,
+        "select": "*",
+    })
+
+    company_ids = [c["id"] for c in companies]
+    sources = {}
+    key_people = {}
+    signals = {}
+    pipeline = {}
+    for cid in company_ids:
+        sources[cid] = supabase_get("research_sources", {
+            "company_id": "eq.%s" % cid, "select": "*",
+        })
+        key_people[cid] = supabase_get("key_people", {
+            "company_id": "eq.%s" % cid, "select": "*",
+        })
+        signals[cid] = supabase_get("signals", {
+            "company_id": "eq.%s" % cid, "select": "*",
+        })
+        pipeline[cid] = supabase_get("pipeline", {
+            "company_id": "eq.%s" % cid, "select": "*",
+        })
+
+    return {
+        "companies": companies,
+        "sources": sources,
+        "key_people": key_people,
+        "signals": signals,
+        "pipeline": pipeline,
+    }
+
+
+def run_agent_session(province, config, prompt):
+    """Run a session and return the timestamp before it started."""
+    before_ts = datetime.now(timezone.utc).isoformat()
+    province_name = PROVINCE_NAMES[province]
+
+    print("\nStarting eval session for %s..." % province_name)
+
+    session = client.beta.sessions.create(
+        agent=config["agent_id"],
+        environment_id=config["environment_id"],
+        title="Eval: %s" % province_name,
+        metadata={"province": province, "eval": "true"},
+    )
+    print("Session: %s" % session.id)
+
+    tool_calls = 0
+    start_time = time.time()
+
+    with client.beta.sessions.events.stream(session.id) as stream:
+        client.beta.sessions.events.send(
+            session.id,
+            events=[{
+                "type": "user.message",
+                "content": [{"type": "text", "text": prompt}],
+            }],
+        )
+
+        for event in stream:
+            etype = event.type
+
+            if etype == "agent.message":
+                for block in event.content:
+                    if hasattr(block, "text"):
+                        print(block.text, end="", flush=True)
+                print()
+            elif etype == "agent.tool_use":
+                tool_calls += 1
+                if tool_calls % 20 == 0:
+                    elapsed = int(time.time() - start_time)
+                    print("\n  [%ds] %d tool calls\n" % (elapsed, tool_calls))
+            elif etype == "session.status_idle":
+                stop_reason = getattr(event, "stop_reason", None)
+                if stop_reason and getattr(stop_reason, "type", "") == "end_turn":
+                    break
+            elif etype == "session.status_terminated":
+                print("\n[SESSION TERMINATED]")
+                break
+
+    elapsed = int(time.time() - start_time)
+    print("\nSession complete in %ds (%d tool calls)" % (elapsed, tool_calls))
+    return before_ts
+
+
+# ═══════════════════════════════════════════════
+# Prospecting Eval
+# ═══════════════════════════════════════════════
+
+def prospecting_prompt(province):
+    province_name = PROVINCE_NAMES[province]
+    return """Prospect for M&A target companies in %s (%s).
+
+EXECUTE THIS WORKFLOW NOW:
+
+1. Export your credentials (SUPABASE_URL, SUPABASE_KEY, SCRAPINGDOG_API_KEY) from your system prompt
+2. Query existing %s companies from Supabase to avoid duplicates
+3. Search for mid-market companies ($10M-$500M revenue) in %s matching the ICP
+4. For each new company found (NOT already in database):
+   a. Research thoroughly (revenue, ownership, industry, key people)
+   b. Score against ICP tiers (Tier 1/2/3 or disqualify)
+   c. Calculate succession scorecard (5 dimensions, 1-5 each)
+   d. Find and scrape LinkedIn profiles for 3-5 key people
+   e. Save everything to Supabase (company, key_people, signals, pipeline, research_sources)
+   f. IMPORTANT: Save at least 5 research sources per company with URLs
+6. Report summary
+
+TARGET: Find at least 5 new companies that qualify as Tier 1 or Tier 2 ICP fits.
+
+Remember: EVERY data point needs a source URL. Skip companies already in the database.""" % (
+        province_name, province, province, province_name
+    )
+
+
+def run_prospecting_eval(province, skip_run=False):
+    config = load_config()
+    RESULTS_DIR.mkdir(exist_ok=True)
+
+    # Pull existing company count
+    existing = supabase_get("companies", {"province": "eq.%s" % province, "select": "id"})
+    print("Existing %s companies: %d" % (province, len(existing)))
+
+    if skip_run:
+        before_ts = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0).isoformat()
+        print("Skipping agent run, using today's data")
+    else:
+        prompt = prospecting_prompt(province)
+        before_ts = run_agent_session(province, config, prompt)
+
+    # Pull agent results
+    print("\nPulling agent results...")
+    results = get_agent_results(province, before_ts)
+    print("Agent found: %d companies" % len(results["companies"]))
+
+    # Score each new company
+    scorecard = ProspectingScorecard(
+        province=province,
+        existing_count=len(existing),
+        new_count=len(results["companies"]),
+        qualified_count=0,
+    )
+
+    for co in results["companies"]:
+        cid = co["id"]
+        ps = score_prospect(
+            co,
+            sources=results["sources"].get(cid),
+            key_people=results["key_people"].get(cid),
+            signals=results["signals"].get(cid),
+            pipeline=results["pipeline"].get(cid),
+        )
+        if ps.revenue_in_range:
+            scorecard.qualified_count += 1
+        scorecard.prospect_scores.append(ps)
+
+    report = scorecard.report()
+    print(report)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = RESULTS_DIR / ("prospecting_%s_%s.txt" % (province, timestamp))
+    report_path.write_text(report)
+    print("Report saved to %s" % report_path)
+
+
+# ═══════════════════════════════════════════════
+# Rediscovery Eval
+# ═══════════════════════════════════════════════
+
+def rediscovery_prompt(province, baseline_names):
+    province_name = PROVINCE_NAMES[province]
+    names_list = "\n".join("- %s" % n for n in baseline_names)
+    return """Research and profile these known %s companies. For each one:
+
+1. Export your credentials from your system prompt
+2. Search for comprehensive information using web_search and web_fetch
+3. Save a complete company profile to Supabase with:
+   - Revenue estimate, employee count, industry, ownership type, website
+   - Succession scorecard (all 5 dimensions scored 1-5)
+   - At least 3 key people with LinkedIn profiles
+   - At least 5 research sources with URLs
+   - Transaction signals detected
+   - Pipeline entry
+4. IMPORTANT: Use UPSERT so existing records are updated, not duplicated
+
+Companies to research:
+%s
+
+Save ALL findings to Supabase. Do NOT skip any company. Research each one independently.""" % (
+        province_name, names_list
+    )
+
+
+def run_rediscovery_eval(province, skip_run=False):
+    config = load_config()
+    RESULTS_DIR.mkdir(exist_ok=True)
+
+    # Pull baseline
+    print("Pulling baseline data for %s..." % province)
+    baseline = get_baseline(province)
+    baseline_names = [c["name"] for c in baseline["companies"]]
+    print("Baseline: %d companies" % len(baseline["companies"]))
+    for name in baseline_names:
+        print("  - %s" % name)
+
+    if skip_run:
+        before_ts = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0).isoformat()
+        print("Skipping agent run, using today's data")
+    else:
+        prompt = rediscovery_prompt(province, baseline_names)
+        before_ts = run_agent_session(province, config, prompt)
+
+    # Pull agent results
+    print("\nPulling agent results...")
+    results = get_agent_results(province, before_ts)
+    print("Agent updated: %d companies" % len(results["companies"]))
+
+    # Score
+    scorecard = RediscoveryScorecard(
+        province=province,
+        baseline_count=len(baseline["companies"]),
+        agent_count=len(results["companies"]),
+    )
+
+    for agent_co in results["companies"]:
+        baseline_match = find_best_match(agent_co, baseline["companies"])
+        cid = agent_co["id"]
+        agent_sources = results["sources"].get(cid, [])
+
+        if baseline_match:
+            scorecard.matched_count += 1
+            cs = score_company(agent_co, baseline_match, agent_sources)
+        else:
+            cs = score_company(agent_co, None, agent_sources)
+
+        scorecard.company_scores.append(cs)
+
+    report = scorecard.report()
+    print(report)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = RESULTS_DIR / ("rediscovery_%s_%s.txt" % (province, timestamp))
+    report_path.write_text(report)
+    print("Report saved to %s" % report_path)
+
+
+# ═══════════════════════════════════════════════
+# Main
+# ═══════════════════════════════════════════════
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python eval.py <PROVINCE> [--rediscovery] [--skip-run]")
+        print("Provinces: NB, NS, PEI, NL")
+        print("")
+        print("Modes:")
+        print("  (default)      Prospecting — find new companies, score quality")
+        print("  --rediscovery  Rediscovery — profile known companies, score accuracy")
+        sys.exit(1)
+
+    province = sys.argv[1].upper()
+    if province not in PROVINCE_NAMES:
+        print("Invalid province: %s. Use: NB, NS, PEI, NL" % province)
+        sys.exit(1)
+
+    skip = "--skip-run" in sys.argv
+    rediscovery = "--rediscovery" in sys.argv
+
+    if rediscovery:
+        run_rediscovery_eval(province, skip_run=skip)
+    else:
+        run_prospecting_eval(province, skip_run=skip)

--- a/managed-agent/icp.md
+++ b/managed-agent/icp.md
@@ -1,0 +1,128 @@
+# Morrison Park Advisors — Ideal Customer Profile
+
+## Deal Size Sweet Spot
+
+| Range | Transaction Value | Typical Revenue |
+|-------|-------------------|-----------------|
+| Core | $30M - $150M | $20M - $100M |
+| Stretch | $150M - $500M | $100M - $300M |
+| Opportunistic | $500M+ | $300M+ |
+
+## Sector Expertise
+
+### Primary Sectors (Deep Expertise)
+- Energy (NL offshore, renewables)
+- Mining (NS, NB mining operations)
+- Healthcare (regional healthcare systems)
+- Financial Services (Atlantic credit unions, insurance)
+
+### Secondary Sectors
+- Industrials / Manufacturing
+- Technology (Halifax tech ecosystem)
+- Telecom
+
+### Gap Sectors (Opportunity)
+- Seafood / Aquaculture
+- Tourism / Hospitality
+- Agriculture / Food Processing
+
+## Ownership Structures
+
+### Primary
+- Founder-owned private (single owner, built from scratch, 20+ years)
+- Family-held (multi-generational, complex shareholder base)
+- PE-backed (financial sponsor seeking exit)
+
+### Secondary
+- Public company (TSX/TSXV, special committee needs)
+- Mission-driven (credit unions, healthcare, housing)
+
+## Qualification Criteria
+
+### Must-Haves (Disqualify if Missing)
+- Revenue >$10M
+- Profitable or clear path to profitability
+- Located in Atlantic Canada (NS, NB, PEI, NL)
+- Private or small-cap public (<$500M market cap)
+- Decision-maker accessible (owner, board, PE sponsor)
+
+### Strong Fit Indicators
+- Owner age 55+ OR PE ownership 5+ years
+- No current investment banking relationship
+- In MPA sector expertise (energy, mining, healthcare, financial services, industrials)
+- $20M-$200M revenue range
+- Clear strategic rationale for transaction (succession, growth capital, consolidation)
+
+### Bonus Indicators
+- Previous M&A activity (acquirer or acquired)
+- Board of directors in place
+- Audited financials
+- Management team beyond founder
+- Industry with active buyer universe
+
+## Disqualifiers
+
+- Revenue <$10M (transaction economics don't work)
+- Distressed with no path forward
+- Owner not interested in transaction
+- Already engaged with competitor advisor
+- Industry MPA has no expertise in
+- Complex legal/regulatory issues
+
+## ICP Tiers
+
+### Tier 1: Ideal Fit
+- Revenue: $30M - $150M
+- Industry: Energy, Mining, Healthcare, Financial Services, Industrials
+- Ownership: Founder-owned 15+ years, owner age 58+
+- Location: Halifax, St. John's, Moncton (major centers)
+- Trigger: Active succession planning or recent trigger event
+
+### Tier 2: Good Fit
+- Revenue: $15M - $30M OR $150M - $300M
+- Industry: Manufacturing, Professional Services, Construction
+- Ownership: Family-held or PE-backed
+- Location: Any Atlantic Canada
+- Trigger: Growth capital need or early succession awareness
+
+### Tier 3: Opportunistic
+- Revenue: $10M - $15M (emerging) OR $300M+ (large)
+- Industry: Adjacent sectors (tech, seafood)
+- Ownership: Various
+- Trigger: Specific situation requiring MPA expertise
+
+## Ideal Customer Triggers
+
+### High-Priority (Act Now)
+- Owner age 60+ (succession window opening)
+- No clear successor (no family in business, no COO/GM)
+- Health event (owner or spouse illness)
+- Partner dispute (legal filings, news)
+- PE fund end-of-life (fund vintage 7+ years)
+
+### Medium-Priority (Nurture)
+- Industry consolidation (competitor acquisitions)
+- Capital needs (expansion plans, equipment age)
+- Regulatory change (new compliance requirements)
+- Key customer concentration (single customer >30% revenue)
+
+### Low-Priority (Long-term)
+- Owner age 50-60 (early succession awareness)
+- Growth mode (hiring, expansion news)
+- Industry tailwinds (sector growth trends)
+
+## Succession Scorecard (1-5 scale)
+
+| Dimension | 1 | 2 | 3 | 4 | 5 |
+|-----------|---|---|---|---|---|
+| Owner Age | <55 | 55-60 | 60-65 | 65-72 | >72 |
+| Tenure | <10yr | 10-15yr | 15-25yr | 25-35yr | >35yr |
+| Next-Gen Clarity | Clear successor | Likely successor | Unclear | Probably none | Definitely none |
+| Legacy Signals | None | Minor | Some philanthropy | Active foundation | Strong legacy focus |
+| Activity Trajectory | Active M&A/growth | Growing steadily | Steady state | Slowing | Divesting/winding down |
+
+**Readiness categories:**
+- 5-10: Low
+- 11-15: Medium
+- 16-20: High
+- 21-25: Very High

--- a/managed-agent/monitor_deploy.py
+++ b/managed-agent/monitor_deploy.py
@@ -1,0 +1,442 @@
+"""
+MPA Company Monitor — Deployment Script
+
+Creates the monitoring agent that watches known pipeline companies
+for news, leadership changes, M&A activity, and succession signals.
+
+Usage:
+    python monitor_deploy.py          # Full deploy
+    python monitor_deploy.py --update # Update system prompt only
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from anthropic import Anthropic
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+ANTHROPIC_API_KEY = os.environ["MPA_ANTHROPIC_API_KEY"]
+SUPABASE_URL = "https://vuuoukfcbucgsqnnsaii.supabase.co"
+SUPABASE_ANON_KEY = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ1dW91a2ZjYnVjZ3Nxbm5zYWlpIiwi"
+    "cm9sZSI6ImFub24iLCJpYXQiOjE3NjQ4OTU4MTgsImV4cCI6MjA4MDQ3MTgxOH0."
+    "L9xpsTOwSpLvY7OdVvsd74oGS6ubVOJxtNCZSiXdjQY"
+)
+SCRAPINGDOG_API_KEY = os.environ["SCRAPING_DOG_API_KEY"]
+
+# Reuse existing environment from prospector
+PROSPECTOR_CONFIG = Path(__file__).parent / "config.json"
+MONITOR_CONFIG = Path(__file__).parent / "monitor_config.json"
+
+client = Anthropic(api_key=ANTHROPIC_API_KEY)
+
+
+SYSTEM_PROMPT = r"""You are the MPA Company Monitor, an autonomous M&A intelligence agent for Morrison Park Advisors (MPA).
+
+MISSION: Monitor known companies in the Supabase pipeline for recent news, leadership changes, M&A activity, product announcements, and succession signals. Save new signals to the database and produce a prioritized weekly digest. You are NOT finding new companies — the Prospector agent does that. You are watching companies we already track.
+
+AUTONOMY MANDATE:
+- Execute ALL tasks immediately without asking permission
+- NEVER say "I would need to..." or "Should I..." — just do it
+- If a search returns no results, try different queries automatically
+- Complete the full monitoring run and report findings at the end
+
+CRITICAL RULES:
+1. EVERY signal MUST have a source URL — non-negotiable for M&A credibility
+2. DEDUP: Check existing signals before saving. Do NOT save duplicate signals.
+3. Rate confidence honestly: high (primary source), medium (secondary), low (inference)
+4. Prioritize companies by succession_composite score (highest first)
+5. Budget: max 200 tool calls per session. If running low, skip LinkedIn scraping and focus on news.
+
+═══════════════════════════════════════════════
+SETUP — Run at the start of every session
+═══════════════════════════════════════════════
+
+Export your credentials immediately:
+```bash
+export SUPABASE_URL="__SUPABASE_URL__"
+export SUPABASE_KEY="__SUPABASE_KEY__"
+export SCRAPINGDOG_API_KEY="__SCRAPINGDOG_API_KEY__"
+```
+
+These are pre-configured. Do NOT ask for credentials — just export and use them.
+
+═══════════════════════════════════════════════
+WORKFLOW
+═══════════════════════════════════════════════
+
+1. EXPORT CREDENTIALS (run the export commands above)
+
+2. PULL PIPELINE COMPANIES to monitor, sorted by succession score:
+```bash
+curl -s "${SUPABASE_URL}/rest/v1/pipeline?stage=not.in.(closed,passed)&select=company_id,stage,priority,client_type,companies(id,name,province,industry,succession_composite,succession_readiness,last_monitored_at)&order=companies.succession_composite.desc" \
+  -H "apikey: ${SUPABASE_KEY}" -H "Authorization: Bearer ${SUPABASE_KEY}"
+```
+
+If filtering by province, add: `&companies.province=eq.NB`
+
+3. FOR EACH COMPANY (highest succession score first):
+
+   a. PULL EXISTING SIGNALS for dedup:
+   ```bash
+   curl -s "${SUPABASE_URL}/rest/v1/signals?company_id=eq.{UUID}&select=signal_type,signal_category,source_url,description&order=created_at.desc&limit=20" \
+     -H "apikey: ${SUPABASE_KEY}" -H "Authorization: Bearer ${SUPABASE_KEY}"
+   ```
+
+   b. SEARCH FOR RECENT NEWS using web_search:
+      - "{company name}" news 2025 OR 2026
+      - "{company name}" acquisition OR merger OR sold
+      - "{founder/CEO name}" "{company name}"
+      - "{company name}" expansion OR contract OR partnership
+      - "{company name}" leadership OR CEO OR president OR appointment
+
+   c. SEARCH FOR OWNERSHIP & LEADERSHIP CHANGES (look back 3-5 years, not just recent):
+      - "{company name}" new CEO OR new president OR appointed
+      - "{company name}" acquired OR investment OR stake OR minority OR majority
+      - "{company name}" ownership OR shareholder OR bought OR sold stake
+      - "{founder name}" retirement OR succession OR stepped down OR departed
+
+   d. SEARCH FOR SUCCESSION SIGNALS:
+      - "{founder name}" philanthropy OR foundation OR donation OR award
+      - "{founder name}" health OR obituary
+      - "{company name}" board changes OR new director
+
+   e. CHECK LINKEDIN for key people (top 10 companies only, max 10 scrapes per session):
+      - Search for recent posts by founder/CEO
+      - Check for headline/title changes
+      - Look for "next chapter", "transition", "legacy" language
+
+   f. ASSESS each finding using the Signal Assessment Framework (below)
+
+   g. CLASSIFY SIGNALS CORRECTLY using these rules:
+      - CEO/President/executive appointment or departure → signal_type: "leadership"
+      - Founder stepping down, retiring, or transitioning role → signal_type: "leadership"
+      - Outside investor taking stake (minority or majority) → signal_type: "buy_side"
+      - Company being acquired or sold → signal_type: "sell_side"
+      - Owner age, succession planning, no successor → signal_type: "sell_side"
+      - Philanthropy, awards, legacy activities → signal_type: "sell_side" (category: "legacy_signals")
+      - PE fund approaching end-of-life, asset sales → signal_type: "sell_side"
+      - New contracts, expansion, hiring → signal_type: "growth"
+      - Revenue milestones, capital raises → signal_type: "financial"
+      - Partnerships, market pivots, technology investments → signal_type: "strategic"
+
+   h. DEDUP CHECK: Before saving any signal, compare against existing signals:
+      - Same source_url? SKIP (exact duplicate)
+      - Same signal_category + very similar description? SKIP (semantic duplicate)
+      - New information from a different source? SAVE (even if same category)
+
+   i. SAVE NEW SIGNALS to Supabase (see API reference below)
+
+   j. UPDATE COMPANY if data changed:
+      - New revenue figure? Update revenue_estimate
+      - Leadership change? Update key_people
+      - Ownership change? Update ownership_type
+      - Recalculate succession scores if warranted
+
+   k. UPDATE last_monitored_at:
+   ```bash
+   curl -s -X PATCH "${SUPABASE_URL}/rest/v1/companies?id=eq.{UUID}" \
+     -H "apikey: ${SUPABASE_KEY}" -H "Authorization: Bearer ${SUPABASE_KEY}" \
+     -H "Content-Type: application/json" \
+     -H "Prefer: return=minimal" \
+     -d '{"last_monitored_at": "2026-04-11T00:00:00Z"}'
+   ```
+   Use today's actual date.
+
+   l. UPDATE PIPELINE priority if warranted:
+      - New URGENT signal? Increase priority
+      - Company acquired/closed? Move to "closed" or "passed"
+
+4. PRODUCE WEEKLY DIGEST (see output format below)
+
+═══════════════════════════════════════════════
+SIGNAL ASSESSMENT FRAMEWORK
+═══════════════════════════════════════════════
+
+Classify every finding into one of four tiers:
+
+### URGENT — Requires immediate attention from Ken
+- Owner health event or obituary
+- Company acquisition announced or rumored
+- PE fund exit filing or process launch
+- Partner dispute or litigation filed
+- Company entering receivership or restructuring
+
+### NOTABLE — Meaningful change, track closely
+- CEO/owner appointment or departure
+- Major contract win or loss (>10% of revenue)
+- Philanthropy milestone (named building, major donation, Order of Canada)
+- New board member appointed
+- Capital raise or new investor
+- Product launch or market expansion
+- Key customer gained or lost
+
+### ROUTINE — Worth recording, low urgency
+- Industry award or recognition
+- Minor expansion (new hire, small office)
+- Conference speaking or panel participation
+- Industry trend affecting the company
+- Competitor news that impacts positioning
+
+### IGNORE — Do not save
+- Social media noise, marketing content
+- Duplicate of existing signal
+- Unverifiable rumors without source
+- Generic industry news not company-specific
+
+═══════════════════════════════════════════════
+OUTPUT FORMAT — Weekly Digest
+═══════════════════════════════════════════════
+
+At the end of the session, produce a digest in this format:
+
+```
+## Weekly Monitoring Digest — [Date]
+
+### URGENT (Action Needed)
+[Company]: [Signal description] — [Source URL]
+  Impact: [Why this matters for MPA]
+  Recommended action: [What Ken should do]
+
+### NOTABLE (Track Closely)
+[Company]: [Signal description] — [Source URL]
+  Impact: [Why this matters]
+
+### ROUTINE (Recorded)
+[Company]: [Signal description]
+
+### Summary
+- Companies monitored: X
+- New signals saved: Y (Z urgent, W notable, V routine)
+- Companies with no new activity: [list]
+- Next monitoring recommended: [date]
+```
+
+═══════════════════════════════════════════════
+SUPABASE REST API REFERENCE
+═══════════════════════════════════════════════
+
+Base URL: ${SUPABASE_URL}/rest/v1
+Headers (always include both):
+  -H "apikey: ${SUPABASE_KEY}"
+  -H "Authorization: Bearer ${SUPABASE_KEY}"
+
+### Read companies with pipeline join
+```bash
+curl -s "${SUPABASE_URL}/rest/v1/companies?province=eq.NB&select=id,name,industry,succession_composite,last_monitored_at" \
+  -H "apikey: ${SUPABASE_KEY}" -H "Authorization: Bearer ${SUPABASE_KEY}"
+```
+
+### Read existing signals for a company (for dedup)
+```bash
+curl -s "${SUPABASE_URL}/rest/v1/signals?company_id=eq.UUID&select=signal_type,signal_category,source_url,description&order=created_at.desc&limit=20" \
+  -H "apikey: ${SUPABASE_KEY}" -H "Authorization: Bearer ${SUPABASE_KEY}"
+```
+
+### Insert signal
+```bash
+curl -s -X POST "${SUPABASE_URL}/rest/v1/signals" \
+  -H "apikey: ${SUPABASE_KEY}" \
+  -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{
+    "company_id": "uuid",
+    "signal_type": "leadership",
+    "signal_category": "ceo_hire",
+    "description": "Jeff Rose appointed as new President, replacing founder Sylvia MacVey",
+    "source_url": "https://source.com/article",
+    "confidence": "high"
+  }'
+```
+signal_type: sell_side, buy_side, growth, leadership, financial, strategic
+signal_category examples: owner_age, no_successor, legacy_signals, ceo_hire, founder_departure, board_change, new_contract, expansion, m&a_announcement, pe_fund_life, asset_sale, capital_raise, partnership, health_event
+
+### Update company (PATCH for partial updates)
+```bash
+curl -s -X PATCH "${SUPABASE_URL}/rest/v1/companies?id=eq.UUID" \
+  -H "apikey: ${SUPABASE_KEY}" -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=minimal" \
+  -d '{"last_monitored_at": "2026-04-11T00:00:00Z", "employee_count": 350}'
+```
+
+### Update pipeline
+```bash
+curl -s -X PATCH "${SUPABASE_URL}/rest/v1/pipeline?company_id=eq.UUID" \
+  -H "apikey: ${SUPABASE_KEY}" -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=minimal" \
+  -d '{"priority": 5, "notes": "URGENT: Owner health event reported"}'
+```
+
+### Insert key person
+```bash
+curl -s -X POST "${SUPABASE_URL}/rest/v1/key_people" \
+  -H "apikey: ${SUPABASE_KEY}" -H "Authorization: Bearer ${SUPABASE_KEY}" \
+  -H "Content-Type: application/json" \
+  -H "Prefer: return=representation" \
+  -d '{
+    "company_id": "uuid",
+    "name": "New Executive",
+    "title": "CEO",
+    "role": "executive",
+    "source_url": "https://source.com"
+  }'
+```
+role: owner, executive, board, other
+
+═══════════════════════════════════════════════
+SCRAPINGDOG LINKEDIN API
+═══════════════════════════════════════════════
+
+### Scrape a LinkedIn profile
+```bash
+curl -s "https://api.scrapingdog.com/linkedin?api_key=${SCRAPINGDOG_API_KEY}&type=profile&linkId=PROFILE_ID&premium=true"
+```
+- Extract PROFILE_ID from URL: https://linkedin.com/in/johnsmith -> johnsmith
+- Always use premium=true
+- Max 10 profile scrapes per monitoring session
+- Only scrape for top-succession-score companies
+- Check for: headline changes, new experience entries, about section updates
+
+### Handle errors
+- HTTP 202: Wait 2 minutes, retry (not charged)
+- HTTP 400/404: Profile not found, skip
+- JSON parsing: Clean control characters with python3 pipe
+
+### Find LinkedIn posts for key people
+Use web_search:
+- site:linkedin.com/posts/ "{person name}"
+- site:linkedin.com/feed/update/ "{person name}"
+Look for: "next chapter", "transition", "legacy", "succession", "retirement"
+
+═══════════════════════════════════════════════
+ATLANTIC CANADA CONTEXT
+═══════════════════════════════════════════════
+
+- Smaller market where news travels fast through networks
+- Regional business publications: Atlantic Business Magazine, Chronicle Herald, Telegraph-Journal
+- Government funding announcements (ACOA, ONB) often signal expansion
+- Key cities: Halifax (NS), Moncton/Saint John/Fredericton (NB), Charlottetown (PEI), St. John's (NL)
+- Family businesses dominate — succession is THE key M&A driver
+"""
+
+
+def build_system_prompt():
+    return (
+        SYSTEM_PROMPT
+        .replace("__SUPABASE_URL__", SUPABASE_URL)
+        .replace("__SUPABASE_KEY__", SUPABASE_ANON_KEY)
+        .replace("__SCRAPINGDOG_API_KEY__", SCRAPINGDOG_API_KEY)
+    )
+
+
+def load_config():
+    if MONITOR_CONFIG.exists():
+        return json.loads(MONITOR_CONFIG.read_text())
+    return {}
+
+
+def save_config(config):
+    MONITOR_CONFIG.write_text(json.dumps(config, indent=2))
+    print("Config saved to %s" % MONITOR_CONFIG)
+
+
+def get_shared_environment_id():
+    """Reuse the environment from the prospector agent."""
+    if PROSPECTOR_CONFIG.exists():
+        prospector = json.loads(PROSPECTOR_CONFIG.read_text())
+        if "environment_id" in prospector:
+            return prospector["environment_id"]
+    return None
+
+
+def deploy():
+    print("=== MPA Company Monitor — Deployment ===\n")
+    config = load_config()
+
+    # 1. Reuse or create environment
+    if "environment_id" not in config:
+        shared_env = get_shared_environment_id()
+        if shared_env:
+            config["environment_id"] = shared_env
+            print("  Reusing environment: %s" % shared_env)
+        else:
+            print("Creating environment...")
+            env = client.beta.environments.create(
+                name="mpa-monitor-env",
+                config={
+                    "type": "cloud",
+                    "packages": {"pip": ["requests"]},
+                    "networking": {"type": "unrestricted"},
+                },
+            )
+            config["environment_id"] = env.id
+            print("  Environment: %s" % env.id)
+    else:
+        print("  Environment exists: %s" % config["environment_id"])
+
+    # 2. Create agent
+    system = build_system_prompt()
+    if "agent_id" not in config:
+        print("Creating agent...")
+        agent = client.beta.agents.create(
+            name="MPA Company Monitor",
+            model="claude-sonnet-4-6",
+            description=(
+                "Weekly monitoring of known pipeline companies for news, "
+                "leadership changes, M&A activity, and succession signals. "
+                "Saves new signals to Supabase and produces prioritized digests."
+            ),
+            system=system,
+            tools=[
+                {
+                    "type": "agent_toolset_20260401",
+                    "default_config": {"enabled": True},
+                }
+            ],
+        )
+        config["agent_id"] = agent.id
+        config["agent_version"] = agent.version
+        print("  Agent: %s (v%d)" % (agent.id, agent.version))
+    else:
+        print("  Agent exists: %s" % config["agent_id"])
+
+    save_config(config)
+
+    print("\n=== Deployment Complete ===")
+    print("  Agent ID:       %s" % config["agent_id"])
+    print("  Environment ID: %s" % config["environment_id"])
+    print("\nRun monitoring:  python monitor_run.py --province NB")
+    print("Run eval:        python monitor_eval.py --detection")
+
+
+def update_agent():
+    config = load_config()
+    if "agent_id" not in config:
+        print("No agent found. Run deploy first.")
+        sys.exit(1)
+
+    print("Updating agent system prompt...")
+    system = build_system_prompt()
+    agent = client.beta.agents.update(
+        agent_id=config["agent_id"],
+        version=config["agent_version"],
+        system=system,
+    )
+    config["agent_version"] = agent.version
+    save_config(config)
+    print("  Agent updated: %s (v%d)" % (agent.id, agent.version))
+
+
+if __name__ == "__main__":
+    if "--update" in sys.argv:
+        update_agent()
+    else:
+        deploy()

--- a/managed-agent/monitor_eval.py
+++ b/managed-agent/monitor_eval.py
@@ -1,0 +1,432 @@
+"""
+MPA Company Monitor — Evaluation Script
+
+Tests signal detection accuracy and dedup behavior.
+
+Usage:
+    python monitor_eval.py --detection           # Test known event detection
+    python monitor_eval.py --detection --province NB  # NB only
+    python monitor_eval.py --dedup --province NB  # Run twice, verify no dupes
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+from anthropic import Anthropic
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+ANTHROPIC_API_KEY = os.environ["MPA_ANTHROPIC_API_KEY"]
+SUPABASE_URL = "https://vuuoukfcbucgsqnnsaii.supabase.co"
+SUPABASE_ANON_KEY = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+    "eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InZ1dW91a2ZjYnVjZ3Nxbm5zYWlpIiwi"
+    "cm9sZSI6ImFub24iLCJpYXQiOjE3NjQ4OTU4MTgsImV4cCI6MjA4MDQ3MTgxOH0."
+    "L9xpsTOwSpLvY7OdVvsd74oGS6ubVOJxtNCZSiXdjQY"
+)
+
+MONITOR_CONFIG = Path(__file__).parent / "monitor_config.json"
+RESULTS_DIR = Path(__file__).parent / "eval_results"
+
+PROVINCE_NAMES = {
+    "NB": "New Brunswick",
+    "NS": "Nova Scotia",
+    "PEI": "Prince Edward Island",
+    "NL": "Newfoundland and Labrador",
+}
+
+client = Anthropic(api_key=ANTHROPIC_API_KEY)
+HEADERS = {
+    "apikey": SUPABASE_ANON_KEY,
+    "Authorization": "Bearer %s" % SUPABASE_ANON_KEY,
+}
+
+# Known verifiable events for detection testing
+KNOWN_EVENTS = [
+    {
+        "company_pattern": "G.E. Barbour",
+        "province": "NB",
+        "expected_signal_type": "leadership",
+        "expected_category": "ceo_hire",
+        "description": "Jeff Rose appointed President replacing Sylvia MacVey (Dec 2025)",
+    },
+    {
+        "company_pattern": "Twin Rivers",
+        "province": "NB",
+        "expected_signal_type": "sell_side",
+        "expected_category": "asset_sale",
+        "description": "Sold Plaster Rock lumber mill to Groupe Lebel (March 2023)",
+    },
+    {
+        "company_pattern": "Ganong",
+        "province": "NB",
+        "expected_signal_type": "buy_side",
+        "expected_category": "pe_backing",
+        "description": "Glenn Cooke / Cooke Inc took minority stake (Oct 2022)",
+    },
+    {
+        "company_pattern": "Moosehead",
+        "province": "NB",
+        "expected_signal_type": "leadership",
+        "expected_category": "founder_transition",
+        "description": "Andrew & Patrick Oland became majority shareholders from Derek Oland (Dec 2024)",
+    },
+    {
+        "company_pattern": "Mariner Partners",
+        "province": "NB",
+        "expected_signal_type": "leadership",
+        "expected_category": "founder_transition",
+        "description": "Co-founder Gerry Pond transitioned from Board Chair to advisory (2024)",
+    },
+]
+
+
+def load_config():
+    if not MONITOR_CONFIG.exists():
+        print("No monitor_config.json found. Run monitor_deploy.py first.")
+        sys.exit(1)
+    return json.loads(MONITOR_CONFIG.read_text())
+
+
+def supabase_get(table, params=None):
+    url = "%s/rest/v1/%s" % (SUPABASE_URL, table)
+    resp = requests.get(url, headers=HEADERS, params=params or {})
+    resp.raise_for_status()
+    return resp.json()
+
+
+def run_monitor_session(config, province=None):
+    """Run a monitoring session and return the timestamp before it started."""
+    from monitor_run import build_prompt
+
+    before_ts = datetime.now(timezone.utc).isoformat()
+    scope = PROVINCE_NAMES.get(province, "All") if province else "All"
+
+    print("\nStarting monitoring session for %s..." % scope)
+    prompt = build_prompt(province)
+
+    session = client.beta.sessions.create(
+        agent=config["agent_id"],
+        environment_id=config["environment_id"],
+        title="Eval Monitor: %s" % scope,
+        metadata={"type": "monitoring_eval", "province": province or "all"},
+    )
+    print("Session: %s" % session.id)
+
+    tool_calls = 0
+    start_time = time.time()
+
+    with client.beta.sessions.events.stream(session.id) as stream:
+        client.beta.sessions.events.send(
+            session.id,
+            events=[{
+                "type": "user.message",
+                "content": [{"type": "text", "text": prompt}],
+            }],
+        )
+
+        for event in stream:
+            etype = event.type
+
+            if etype == "agent.message":
+                for block in event.content:
+                    if hasattr(block, "text"):
+                        print(block.text, end="", flush=True)
+                print()
+            elif etype == "agent.tool_use":
+                tool_calls += 1
+                if tool_calls % 20 == 0:
+                    elapsed = int(time.time() - start_time)
+                    print("\n  [%ds] %d tool calls\n" % (elapsed, tool_calls))
+            elif etype == "session.status_idle":
+                stop_reason = getattr(event, "stop_reason", None)
+                if stop_reason and getattr(stop_reason, "type", "") == "end_turn":
+                    break
+            elif etype == "session.status_terminated":
+                print("\n[SESSION TERMINATED]")
+                break
+
+    elapsed = int(time.time() - start_time)
+    print("\nSession complete in %ds (%d tool calls)" % (elapsed, tool_calls))
+    return before_ts
+
+
+def get_signals_since(since, province=None):
+    """Get all signals created after a timestamp, optionally filtered by province."""
+    params = {"created_at": "gte.%s" % since, "select": "*,companies(name,province)"}
+    signals = supabase_get("signals", params)
+    if province:
+        signals = [s for s in signals if s.get("companies", {}).get("province") == province]
+    return signals
+
+
+def check_event_detected(known_event, signals):
+    """Check if a known event was detected in a signal list."""
+    pattern = known_event["company_pattern"].lower()
+    expected_type = known_event["expected_signal_type"]
+
+    for sig in signals:
+        company_name = sig.get("companies", {}).get("name", "").lower()
+        if pattern not in company_name:
+            continue
+        if sig.get("signal_type") == expected_type:
+            return True
+        if known_event.get("expected_category") and sig.get("signal_category") == known_event["expected_category"]:
+            return True
+    return False
+
+
+def check_event_preexisting(known_event, province=None):
+    """Check if a known event already exists in the DB (saved by prospector or prior monitor).
+
+    Uses flexible matching: checks signal_type, signal_category, AND description keywords.
+    Signals may be classified differently by different agents — that's expected.
+    """
+    pattern = known_event["company_pattern"].lower()
+    expected_type = known_event["expected_signal_type"]
+    # Extract key terms from the event description for fuzzy matching
+    desc_keywords = _extract_keywords(known_event["description"])
+
+    all_signals = supabase_get("signals", {"select": "*,companies(name,province)"})
+    for sig in all_signals:
+        company_name = sig.get("companies", {}).get("name", "").lower()
+        if pattern not in company_name:
+            continue
+        # Exact type match
+        if sig.get("signal_type") == expected_type:
+            return True
+        # Exact category match
+        if known_event.get("expected_category") and sig.get("signal_category") == known_event["expected_category"]:
+            return True
+        # Keyword match in description — if 2+ key terms appear, it's the same event
+        sig_desc = (sig.get("description") or "").lower()
+        sig_cat = (sig.get("signal_category") or "").lower()
+        matches = sum(1 for kw in desc_keywords if kw in sig_desc or kw in sig_cat)
+        if matches >= 2:
+            return True
+    return False
+
+
+def _extract_keywords(description):
+    """Extract meaningful keywords from an event description for fuzzy matching."""
+    # Remove common words, keep names and action words
+    stopwords = {
+        "the", "a", "an", "and", "or", "of", "in", "to", "for", "from",
+        "by", "as", "on", "at", "was", "is", "are", "were", "been", "be",
+        "has", "had", "have", "with", "that", "this", "it", "its",
+    }
+    words = description.lower().replace("(", "").replace(")", "").replace(",", "").split()
+    return [w for w in words if w not in stopwords and len(w) > 3]
+
+
+def run_detection_eval(province=None):
+    """Test whether the agent detects known verifiable events."""
+    config = load_config()
+    RESULTS_DIR.mkdir(exist_ok=True)
+
+    # Filter known events by province if specified
+    events_to_check = KNOWN_EVENTS
+    if province:
+        events_to_check = [e for e in KNOWN_EVENTS if e["province"] == province]
+
+    print("Known events to detect: %d" % len(events_to_check))
+    for e in events_to_check:
+        print("  - %s: %s" % (e["company_pattern"], e["description"]))
+
+    # Run monitoring session
+    before_ts = run_monitor_session(config, province)
+
+    # Pull signals created during session
+    print("\nPulling signals created since session start...")
+    new_signals = get_signals_since(before_ts, province)
+    print("New signals found: %d" % len(new_signals))
+
+    # Check each known event — distinguish new detection vs. correct dedup vs. missed
+    detected = 0
+    already_known = 0
+    missed = 0
+    results = []
+    for event in events_to_check:
+        found_new = check_event_detected(event, new_signals)
+        if found_new:
+            detected += 1
+            results.append({
+                "event": event["description"],
+                "company": event["company_pattern"],
+                "status": "DETECTED",
+            })
+        else:
+            preexisting = check_event_preexisting(event, province)
+            if preexisting:
+                already_known += 1
+                results.append({
+                    "event": event["description"],
+                    "company": event["company_pattern"],
+                    "status": "ALREADY_KNOWN",
+                })
+            else:
+                missed += 1
+                results.append({
+                    "event": event["description"],
+                    "company": event["company_pattern"],
+                    "status": "MISSED",
+                })
+
+    # Count companies with last_monitored_at updated
+    if province:
+        companies = supabase_get("companies", {
+            "province": "eq.%s" % province,
+            "last_monitored_at": "not.is.null",
+            "select": "id",
+        })
+    else:
+        companies = supabase_get("companies", {
+            "last_monitored_at": "not.is.null",
+            "select": "id",
+        })
+    monitored_count = len(companies)
+
+    # Source quality — signals with valid source_url
+    signals_with_source = sum(1 for s in new_signals if s.get("source_url"))
+    source_quality = signals_with_source / len(new_signals) if new_signals else 0
+
+    # Scorecard — coverage = detected + already_known (both mean the system has it)
+    total_covered = detected + already_known
+    coverage_rate = total_covered / len(events_to_check) if events_to_check else 0
+    miss_rate = missed / len(events_to_check) if events_to_check else 0
+
+    lines = [
+        "",
+        "=" * 60,
+        "MONITORING DETECTION SCORECARD — %s" % (province or "ALL"),
+        "=" * 60,
+        "",
+        "Known events tested:    %d" % len(events_to_check),
+        "Newly detected:         %d (found by monitor this session)" % detected,
+        "Already known:          %d (correctly deduped — prospector found these)" % already_known,
+        "Missed:                 %d (not in DB at all)" % missed,
+        "New signals saved:      %d" % len(new_signals),
+        "Companies monitored:    %d" % monitored_count,
+        "",
+        "--- Metrics ---",
+        "",
+        "Event coverage:         %.0f%%  (target: >=70%%) [detected + already_known]" % (coverage_rate * 100),
+        "Source quality:          %.0f%%  (target: >=90%%)" % (source_quality * 100),
+        "New signals this run:   %d" % len(new_signals),
+        "",
+        "--- Pass/Fail ---",
+        "",
+    ]
+
+    thresholds = {
+        "Event coverage": (coverage_rate, 0.70),
+        "Source quality": (source_quality, 0.90),
+    }
+
+    all_pass = True
+    for name, (value, threshold) in thresholds.items():
+        passed = value >= threshold
+        if not passed:
+            all_pass = False
+        lines.append("  [%s] %s" % ("PASS" if passed else "FAIL", name))
+
+    lines.append("")
+    lines.append("Overall: %s" % ("PASS" if all_pass else "FAIL — iterate on system prompt"))
+
+    lines.append("")
+    lines.append("--- Event Detection Details ---")
+    lines.append("")
+    for r in results:
+        lines.append("  [%s] %s — %s" % (r["status"], r["company"], r["event"]))
+
+    lines.append("")
+    lines.append("=" * 60)
+
+    report = "\n".join(lines)
+    print(report)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = RESULTS_DIR / ("monitor_detection_%s_%s.txt" % (province or "all", timestamp))
+    report_path.write_text(report)
+    print("Report saved to %s" % report_path)
+
+
+def run_dedup_eval(province=None):
+    """Run monitoring twice and verify no duplicate signals on second pass."""
+    config = load_config()
+    RESULTS_DIR.mkdir(exist_ok=True)
+
+    print("=== DEDUP EVAL: Run 1 ===")
+    ts1 = run_monitor_session(config, province)
+    signals_run1 = get_signals_since(ts1, province)
+    print("Run 1 signals: %d" % len(signals_run1))
+
+    print("\n=== DEDUP EVAL: Run 2 ===")
+    ts2 = run_monitor_session(config, province)
+    signals_run2 = get_signals_since(ts2, province)
+    print("Run 2 signals: %d" % len(signals_run2))
+
+    # Check for duplicates — same source_url appearing in both runs
+    run1_urls = set(s.get("source_url", "") for s in signals_run1 if s.get("source_url"))
+    duplicates = [s for s in signals_run2 if s.get("source_url") in run1_urls]
+
+    dedup_accuracy = 1.0 - (len(duplicates) / len(signals_run2)) if signals_run2 else 1.0
+
+    lines = [
+        "",
+        "=" * 60,
+        "MONITORING DEDUP SCORECARD — %s" % (province or "ALL"),
+        "=" * 60,
+        "",
+        "Run 1 signals:    %d" % len(signals_run1),
+        "Run 2 signals:    %d" % len(signals_run2),
+        "Duplicates found: %d" % len(duplicates),
+        "",
+        "Dedup accuracy:   %.0f%%  (target: >=90%%)" % (dedup_accuracy * 100),
+        "",
+        "--- Pass/Fail ---",
+        "",
+        "  [%s] Dedup accuracy" % ("PASS" if dedup_accuracy >= 0.90 else "FAIL"),
+        "",
+    ]
+
+    if duplicates:
+        lines.append("--- Duplicate Signals ---")
+        lines.append("")
+        for d in duplicates:
+            lines.append("  %s — %s" % (d.get("signal_category", "?"), d.get("source_url", "?")))
+
+    lines.append("")
+    lines.append("=" * 60)
+
+    report = "\n".join(lines)
+    print(report)
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    report_path = RESULTS_DIR / ("monitor_dedup_%s_%s.txt" % (province or "all", timestamp))
+    report_path.write_text(report)
+    print("Report saved to %s" % report_path)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or "--detection" not in sys.argv and "--dedup" not in sys.argv:
+        print("Usage: python monitor_eval.py --detection [--province NB]")
+        print("       python monitor_eval.py --dedup [--province NB]")
+        sys.exit(1)
+
+    prov = None
+    if "--province" in sys.argv:
+        idx = sys.argv.index("--province")
+        if idx + 1 < len(sys.argv):
+            prov = sys.argv[idx + 1].upper()
+
+    if "--detection" in sys.argv:
+        run_detection_eval(prov)
+    elif "--dedup" in sys.argv:
+        run_dedup_eval(prov)

--- a/managed-agent/monitor_run.py
+++ b/managed-agent/monitor_run.py
@@ -1,0 +1,177 @@
+"""
+MPA Company Monitor — Session Runner
+
+Runs a monitoring session against pipeline companies.
+
+Usage:
+    python monitor_run.py                # Monitor all active pipeline companies
+    python monitor_run.py --province NB  # Monitor NB companies only
+"""
+
+import json
+import os
+import sys
+import time
+from datetime import date
+from pathlib import Path
+
+from anthropic import Anthropic
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+ANTHROPIC_API_KEY = os.environ["MPA_ANTHROPIC_API_KEY"]
+MONITOR_CONFIG = Path(__file__).parent / "monitor_config.json"
+
+PROVINCE_NAMES = {
+    "NB": "New Brunswick",
+    "NS": "Nova Scotia",
+    "PEI": "Prince Edward Island",
+    "NL": "Newfoundland and Labrador",
+}
+
+client = Anthropic(api_key=ANTHROPIC_API_KEY)
+
+
+def load_config():
+    if not MONITOR_CONFIG.exists():
+        print("No monitor_config.json found. Run monitor_deploy.py first.")
+        sys.exit(1)
+    return json.loads(MONITOR_CONFIG.read_text())
+
+
+def build_prompt(province=None):
+    today = date.today().isoformat()
+    province_filter = ""
+    scope = "all active pipeline companies"
+
+    if province:
+        province_name = PROVINCE_NAMES.get(province, province)
+        province_filter = " Filter to %s (%s) companies only." % (province_name, province)
+        scope = "%s pipeline companies" % province_name
+
+    return """Run weekly monitoring for %s. Today's date is %s.
+
+EXECUTE THIS WORKFLOW NOW:
+
+1. Export your credentials from your system prompt
+2. Pull all active pipeline companies (not closed/passed), sorted by succession_composite DESC.%s
+3. For each company:
+   a. Pull existing signals (for dedup)
+   b. Search for recent news: "{company name}" news 2026, "{founder name}" {company name}
+   c. Search for succession signals: "{founder name}" retirement OR philanthropy OR award
+   d. Search for deal activity: "{company name}" acquisition OR merger OR investment
+   e. For top-scoring companies: check LinkedIn activity of key people
+   f. Assess each finding (URGENT/NOTABLE/ROUTINE/IGNORE)
+   g. Dedup against existing signals — do NOT save duplicates
+   h. Save new signals to Supabase with source URLs
+   i. Update last_monitored_at timestamp for each company checked
+   j. Update pipeline priority if warranted
+4. Produce weekly digest grouped by URGENT/NOTABLE/ROUTINE
+
+EFFICIENCY RULES:
+- Start with highest succession_composite companies
+- Spend more time on High/Very High readiness companies
+- For Low readiness companies, a quick news search is sufficient
+- If budget is running low (150+ tool calls), skip LinkedIn scraping
+- Always update last_monitored_at even if no news found""" % (scope, today, province_filter)
+
+
+def run_monitoring(province=None):
+    config = load_config()
+    prompt = build_prompt(province)
+
+    scope = "All Provinces"
+    if province:
+        scope = PROVINCE_NAMES.get(province, province)
+
+    print("\n" + "=" * 60)
+    print("MPA Company Monitor — %s" % scope)
+    print("=" * 60 + "\n")
+
+    print("Creating session...")
+    metadata = {"type": "monitoring"}
+    if province:
+        metadata["province"] = province
+
+    session = client.beta.sessions.create(
+        agent=config["agent_id"],
+        environment_id=config["environment_id"],
+        title="Monitor: %s" % scope,
+        metadata=metadata,
+    )
+    print("Session: %s\n" % session.id)
+
+    tool_calls = 0
+    signals_saved = 0
+    start_time = time.time()
+
+    with client.beta.sessions.events.stream(session.id) as stream:
+        client.beta.sessions.events.send(
+            session.id,
+            events=[{
+                "type": "user.message",
+                "content": [{"type": "text", "text": prompt}],
+            }],
+        )
+
+        for event in stream:
+            etype = event.type
+
+            if etype == "agent.message":
+                for block in event.content:
+                    if hasattr(block, "text"):
+                        print(block.text, end="", flush=True)
+                print()
+
+            elif etype == "agent.tool_use":
+                tool_calls += 1
+                tool_name = event.name
+                if "bash" in tool_name:
+                    input_text = str(getattr(event, "input", ""))
+                    if "rest/v1/signals" in input_text and "POST" in input_text:
+                        signals_saved += 1
+                if tool_calls % 20 == 0:
+                    elapsed = int(time.time() - start_time)
+                    print(
+                        "\n  [%ds] %d tool calls, ~%d signals saved\n"
+                        % (elapsed, tool_calls, signals_saved)
+                    )
+
+            elif etype == "session.status_idle":
+                stop_reason = getattr(event, "stop_reason", None)
+                if stop_reason and getattr(stop_reason, "type", "") == "end_turn":
+                    break
+
+            elif etype == "session.status_terminated":
+                print("\n[SESSION TERMINATED]")
+                error = getattr(event, "error", None)
+                if error:
+                    print("Error: %s" % error)
+                break
+
+            elif etype == "session.error":
+                print("\n[ERROR] %s" % event)
+
+    elapsed = int(time.time() - start_time)
+    print("\n" + "=" * 60)
+    print("Monitoring complete in %ds" % elapsed)
+    print("Tool calls: %d" % tool_calls)
+    print("Signals saved (estimated): %d" % signals_saved)
+    print("Session ID: %s" % session.id)
+    print("=" * 60)
+
+    return session.id
+
+
+if __name__ == "__main__":
+    prov = None
+    if "--province" in sys.argv:
+        idx = sys.argv.index("--province")
+        if idx + 1 < len(sys.argv):
+            prov = sys.argv[idx + 1].upper()
+            if prov not in PROVINCE_NAMES:
+                print("Invalid province: %s. Use: NB, NS, PEI, NL" % prov)
+                sys.exit(1)
+
+    run_monitoring(prov)

--- a/managed-agent/requirements.txt
+++ b/managed-agent/requirements.txt
@@ -1,0 +1,2 @@
+anthropic>=0.52.0
+python-dotenv>=1.0.0

--- a/managed-agent/run_session.py
+++ b/managed-agent/run_session.py
@@ -1,0 +1,182 @@
+"""
+MPA Province Prospector — Session Runner
+
+Starts a prospecting session for a specific province and streams results.
+
+Usage:
+    python run_session.py NB              # Prospect in New Brunswick
+    python run_session.py NS              # Prospect in Nova Scotia
+    python run_session.py PEI             # Prospect in PEI
+    python run_session.py NL              # Prospect in Newfoundland & Labrador
+    python run_session.py NB --prompt "custom prompt"  # Custom task
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+from anthropic import Anthropic
+from dotenv import load_dotenv
+import os
+
+load_dotenv(Path(__file__).parent.parent / ".env")
+
+ANTHROPIC_API_KEY = os.environ["MPA_ANTHROPIC_API_KEY"]
+CONFIG_PATH = Path(__file__).parent / "config.json"
+
+PROVINCE_NAMES = {
+    "NB": "New Brunswick",
+    "NS": "Nova Scotia",
+    "PEI": "Prince Edward Island",
+    "NL": "Newfoundland and Labrador",
+}
+
+client = Anthropic(api_key=ANTHROPIC_API_KEY)
+
+
+def load_config() -> dict:
+    if not CONFIG_PATH.exists():
+        print("No config.json found. Run deploy.py first.")
+        sys.exit(1)
+    return json.loads(CONFIG_PATH.read_text())
+
+
+def build_prompt(province: str, custom_prompt=None) -> str:
+    province_name = PROVINCE_NAMES.get(province, province)
+
+    if custom_prompt:
+        return custom_prompt
+
+    return f"""Prospect for M&A target companies in {province_name} ({province}).
+
+EXECUTE THIS WORKFLOW NOW:
+
+1. Export your credentials (SUPABASE_URL, SUPABASE_KEY, SCRAPINGDOG_API_KEY) from your system prompt
+2. Query existing {province} companies from Supabase to avoid duplicates
+4. Search for mid-market companies ($10M-$500M revenue) in {province_name} matching the ICP
+5. For each new company found (NOT already in database):
+   a. Research thoroughly (revenue, ownership, industry, key people)
+   b. Score against ICP tiers (Tier 1/2/3 or disqualify)
+   c. Calculate succession scorecard (5 dimensions, 1-5 each)
+   d. Find and scrape LinkedIn profiles for 3-5 key people
+   e. Save everything to Supabase (company, key_people, signals, pipeline, research_sources)
+6. Report summary
+
+TARGET: Find at least 5 new companies that qualify as Tier 1 or Tier 2 ICP fits.
+
+Search strategies:
+- "{province_name} largest private companies"
+- "{province_name} family business founder owner"
+- "{province_name} top employers private company"
+- "{province_name} business acquisition merger"
+- "{province_name} fastest growing companies award"
+- Sector-specific searches for energy, manufacturing, healthcare, financial services, construction
+
+Remember: EVERY data point needs a source URL. Skip companies already in the database."""
+
+
+def run_session(province: str, custom_prompt=None):
+    config = load_config()
+    prompt = build_prompt(province, custom_prompt)
+
+    province_name = PROVINCE_NAMES.get(province, province)
+    print(f"\n{'='*60}")
+    print(f"MPA Province Prospector — {province_name}")
+    print(f"{'='*60}\n")
+
+    # Create session
+    print("Creating session...")
+    session = client.beta.sessions.create(
+        agent=config["agent_id"],
+        environment_id=config["environment_id"],
+        title=f"Prospect: {province_name}",
+        metadata={"province": province},
+    )
+    print(f"Session: {session.id}\n")
+
+    # Stream events
+    tool_calls = 0
+    companies_saved = 0
+    start_time = time.time()
+
+    with client.beta.sessions.events.stream(session.id) as stream:
+        # Send the prospecting prompt
+        client.beta.sessions.events.send(
+            session.id,
+            events=[
+                {
+                    "type": "user.message",
+                    "content": [{"type": "text", "text": prompt}],
+                }
+            ],
+        )
+
+        for event in stream:
+            etype = event.type
+
+            if etype == "agent.message":
+                for block in event.content:
+                    if hasattr(block, "text"):
+                        print(block.text, end="", flush=True)
+                print()
+
+            elif etype == "agent.tool_use":
+                tool_calls += 1
+                tool_name = event.name
+                # Track company saves
+                if "bash" in tool_name:
+                    input_text = str(getattr(event, "input", ""))
+                    if "rest/v1/companies" in input_text and "POST" in input_text:
+                        companies_saved += 1
+                if tool_calls % 10 == 0:
+                    elapsed = int(time.time() - start_time)
+                    print(
+                        f"\n  [{elapsed}s] {tool_calls} tool calls, "
+                        f"~{companies_saved} companies saved\n"
+                    )
+
+            elif etype == "session.status_idle":
+                stop_reason = getattr(event, "stop_reason", None)
+                if stop_reason and getattr(stop_reason, "type", "") == "end_turn":
+                    break
+
+            elif etype == "session.status_terminated":
+                print("\n[SESSION TERMINATED]")
+                error = getattr(event, "error", None)
+                if error:
+                    print(f"Error: {error}")
+                break
+
+            elif etype == "session.error":
+                print(f"\n[ERROR] {event}")
+
+    elapsed = int(time.time() - start_time)
+    print(f"\n{'='*60}")
+    print(f"Session complete in {elapsed}s")
+    print(f"Tool calls: {tool_calls}")
+    print(f"Companies saved (estimated): {companies_saved}")
+    print(f"Session ID: {session.id}")
+    print(f"{'='*60}")
+
+    return session.id
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python run_session.py <PROVINCE> [--prompt 'custom prompt']")
+        print("Provinces: NB, NS, PEI, NL")
+        sys.exit(1)
+
+    province = sys.argv[1].upper()
+    if province not in PROVINCE_NAMES:
+        print(f"Invalid province: {province}. Use: NB, NS, PEI, NL")
+        sys.exit(1)
+
+    custom_prompt = None
+    if "--prompt" in sys.argv:
+        idx = sys.argv.index("--prompt")
+        if idx + 1 < len(sys.argv):
+            custom_prompt = sys.argv[idx + 1]
+
+    run_session(province, custom_prompt)

--- a/managed-agent/scoring.py
+++ b/managed-agent/scoring.py
@@ -1,0 +1,543 @@
+"""
+MPA Province Prospector — Scoring Functions
+
+Two eval modes:
+  1. Rediscovery — Agent profiles known companies. Measures accuracy.
+  2. Prospecting — Agent finds new companies. Measures quality and novelty.
+"""
+
+from difflib import SequenceMatcher
+from dataclasses import dataclass, field
+from typing import Optional, List, Dict
+
+
+# ═══════════════════════════════════════════════
+# Data classes
+# ═══════════════════════════════════════════════
+
+@dataclass
+class CompanyScore:
+    """Score for a single company comparison (rediscovery mode)."""
+
+    name: str
+    baseline_name: str
+    matched: bool = False
+    revenue_accurate: Optional[bool] = None
+    revenue_baseline: Optional[float] = None
+    revenue_agent: Optional[float] = None
+    ownership_match: Optional[bool] = None
+    industry_match: Optional[bool] = None
+    succession_deltas: dict = field(default_factory=dict)
+    key_people_overlap: Optional[float] = None
+    source_count: int = 0
+    icp_tier: Optional[int] = None
+    notes: str = ""
+
+
+@dataclass
+class ProspectScore:
+    """Score for a single company in prospecting mode."""
+
+    name: str
+    has_revenue: bool = False
+    has_ownership_type: bool = False
+    has_industry: bool = False
+    has_succession_scores: bool = False
+    has_website: bool = False
+    revenue_in_range: bool = False  # $10M-$500M
+    icp_tier: Optional[int] = None
+    source_count: int = 0
+    key_people_count: int = 0
+    signal_count: int = 0
+    has_pipeline_entry: bool = False
+    completeness: float = 0.0  # 0-1, how many fields populated
+
+    @property
+    def research_depth(self):
+        """Score 0-10 based on how thorough the research is."""
+        score = 0
+        if self.has_revenue:
+            score += 1
+        if self.has_ownership_type:
+            score += 1
+        if self.has_industry:
+            score += 1
+        if self.has_succession_scores:
+            score += 2
+        if self.has_website:
+            score += 1
+        if self.source_count >= 5:
+            score += 2
+        elif self.source_count >= 3:
+            score += 1
+        if self.key_people_count >= 3:
+            score += 1
+        if self.signal_count >= 1:
+            score += 1
+        return score
+
+
+# ═══════════════════════════════════════════════
+# Rediscovery Scorecard
+# ═══════════════════════════════════════════════
+
+@dataclass
+class RediscoveryScorecard:
+    """Scorecard for rediscovery eval — agent profiles known companies."""
+
+    province: str
+    baseline_count: int = 0
+    agent_count: int = 0
+    matched_count: int = 0
+    company_scores: list = field(default_factory=list)
+
+    @property
+    def discovery_rate(self):
+        if self.baseline_count == 0:
+            return 0
+        return self.matched_count / self.baseline_count
+
+    @property
+    def revenue_accuracy(self):
+        scored = [s for s in self.company_scores if s.revenue_accurate is not None]
+        if not scored:
+            return 0
+        return sum(1 for s in scored if s.revenue_accurate) / len(scored)
+
+    @property
+    def ownership_accuracy(self):
+        scored = [s for s in self.company_scores if s.ownership_match is not None]
+        if not scored:
+            return 0
+        return sum(1 for s in scored if s.ownership_match) / len(scored)
+
+    @property
+    def industry_accuracy(self):
+        scored = [s for s in self.company_scores if s.industry_match is not None]
+        if not scored:
+            return 0
+        return sum(1 for s in scored if s.industry_match) / len(scored)
+
+    @property
+    def succession_within_1(self):
+        deltas = []
+        for s in self.company_scores:
+            for dim, delta in s.succession_deltas.items():
+                if delta is not None:
+                    deltas.append(abs(delta))
+        if not deltas:
+            return 0
+        return sum(1 for d in deltas if d <= 1) / len(deltas)
+
+    @property
+    def avg_source_count(self):
+        counts = [s.source_count for s in self.company_scores if s.source_count > 0]
+        if not counts:
+            return 0
+        return sum(counts) / len(counts)
+
+    def report(self):
+        lines = [
+            "",
+            "=" * 60,
+            "REDISCOVERY SCORECARD — %s" % self.province,
+            "=" * 60,
+            "",
+            "Baseline companies:     %d" % self.baseline_count,
+            "Agent discoveries:      %d" % self.agent_count,
+            "Matched to baseline:    %d" % self.matched_count,
+            "",
+            "--- Accuracy Metrics ---",
+            "",
+            "Discovery rate:         %.0f%%  (target: >=70%%)" % (self.discovery_rate * 100),
+            "Revenue accuracy:       %.0f%%  (target: >=80%%)" % (self.revenue_accuracy * 100),
+            "Ownership match:        %.0f%%  (target: >=90%%)" % (self.ownership_accuracy * 100),
+            "Industry match:         %.0f%%  (target: >=85%%)" % (self.industry_accuracy * 100),
+            "Succession within +/-1: %.0f%%  (target: >=75%%)" % (self.succession_within_1 * 100),
+            "Avg sources/company:    %.1f  (target: >=5)" % self.avg_source_count,
+            "",
+        ]
+
+        thresholds = {
+            "Discovery rate": (self.discovery_rate, 0.70),
+            "Revenue accuracy": (self.revenue_accuracy, 0.80),
+            "Ownership match": (self.ownership_accuracy, 0.90),
+            "Industry match": (self.industry_accuracy, 0.85),
+            "Succession scores": (self.succession_within_1, 0.75),
+            "Source coverage": (self.avg_source_count / 5 if self.avg_source_count else 0, 1.0),
+        }
+
+        lines.append("--- Pass/Fail ---")
+        lines.append("")
+        all_pass = True
+        for name, (value, threshold) in thresholds.items():
+            passed = value >= threshold
+            if not passed:
+                all_pass = False
+            lines.append("  [%s] %s" % ("PASS" if passed else "FAIL", name))
+
+        lines.append("")
+        verdict = "PASS — ready for production" if all_pass else "FAIL — iterate on system prompt"
+        lines.append("Overall: %s" % verdict)
+
+        if self.company_scores:
+            lines.append("")
+            lines.append("--- Company Details ---")
+            lines.append("")
+            for cs in self.company_scores:
+                if cs.matched:
+                    rev_str = ""
+                    if cs.revenue_baseline and cs.revenue_agent:
+                        pct = abs(cs.revenue_agent - cs.revenue_baseline) / cs.revenue_baseline * 100
+                        rev_str = " ($%.0fM vs $%.0fM, %.0f%% off)" % (
+                            cs.revenue_agent, cs.revenue_baseline, pct
+                        )
+                    lines.append(
+                        "  %s -> %s  own=%s  ind=%s  rev=%s%s  sources=%d" % (
+                            cs.name, cs.baseline_name,
+                            "Y" if cs.ownership_match else "N",
+                            "Y" if cs.industry_match else "N",
+                            "Y" if cs.revenue_accurate else "N",
+                            rev_str, cs.source_count,
+                        )
+                    )
+                else:
+                    lines.append("  %s (NOT MATCHED)" % cs.name)
+
+        lines.append("")
+        lines.append("=" * 60)
+        return "\n".join(lines)
+
+
+# ═══════════════════════════════════════════════
+# Prospecting Scorecard
+# ═══════════════════════════════════════════════
+
+@dataclass
+class ProspectingScorecard:
+    """Scorecard for prospecting eval — agent finds new companies."""
+
+    province: str
+    existing_count: int = 0
+    new_count: int = 0
+    qualified_count: int = 0  # passed ICP must-haves
+    disqualified_count: int = 0  # correctly rejected
+    prospect_scores: list = field(default_factory=list)
+
+    @property
+    def avg_research_depth(self):
+        if not self.prospect_scores:
+            return 0
+        return sum(s.research_depth for s in self.prospect_scores) / len(self.prospect_scores)
+
+    @property
+    def avg_source_count(self):
+        counts = [s.source_count for s in self.prospect_scores]
+        if not counts:
+            return 0
+        return sum(counts) / len(counts)
+
+    @property
+    def avg_key_people(self):
+        counts = [s.key_people_count for s in self.prospect_scores]
+        if not counts:
+            return 0
+        return sum(counts) / len(counts)
+
+    @property
+    def completeness(self):
+        if not self.prospect_scores:
+            return 0
+        return sum(s.completeness for s in self.prospect_scores) / len(self.prospect_scores)
+
+    @property
+    def tier_distribution(self):
+        tiers = {}
+        for s in self.prospect_scores:
+            t = s.icp_tier or 0
+            tiers[t] = tiers.get(t, 0) + 1
+        return tiers
+
+    def report(self):
+        lines = [
+            "",
+            "=" * 60,
+            "PROSPECTING SCORECARD — %s" % self.province,
+            "=" * 60,
+            "",
+            "Existing companies:     %d" % self.existing_count,
+            "New companies found:    %d" % self.new_count,
+            "Qualified (ICP fit):    %d" % self.qualified_count,
+            "",
+            "--- Quality Metrics ---",
+            "",
+            "Avg research depth:     %.1f/10  (target: >=6)" % self.avg_research_depth,
+            "Avg sources/company:    %.1f  (target: >=5)" % self.avg_source_count,
+            "Avg key people/company: %.1f  (target: >=3)" % self.avg_key_people,
+            "Data completeness:      %.0f%%  (target: >=70%%)" % (self.completeness * 100),
+            "",
+        ]
+
+        # ICP tier distribution
+        tiers = self.tier_distribution
+        lines.append("--- ICP Tier Distribution ---")
+        lines.append("")
+        for t in [1, 2, 3, 0]:
+            count = tiers.get(t, 0)
+            label = {1: "Tier 1 (Ideal)", 2: "Tier 2 (Good)", 3: "Tier 3 (Opportunistic)", 0: "Unclassified"}
+            lines.append("  %s: %d" % (label[t], count))
+        lines.append("")
+
+        # Pass/fail
+        thresholds = {
+            "New companies found": (self.new_count, 3),
+            "Research depth": (self.avg_research_depth, 6.0),
+            "Source coverage": (self.avg_source_count, 5.0),
+            "Key people coverage": (self.avg_key_people, 3.0),
+            "Data completeness": (self.completeness, 0.70),
+        }
+
+        lines.append("--- Pass/Fail ---")
+        lines.append("")
+        all_pass = True
+        for name, (value, threshold) in thresholds.items():
+            passed = value >= threshold
+            if not passed:
+                all_pass = False
+            lines.append("  [%s] %s (%.1f vs %.1f)" % (
+                "PASS" if passed else "FAIL", name, value, threshold
+            ))
+
+        lines.append("")
+        verdict = "PASS — ready for production" if all_pass else "FAIL — iterate on system prompt"
+        lines.append("Overall: %s" % verdict)
+
+        # Per-company details
+        if self.prospect_scores:
+            lines.append("")
+            lines.append("--- Company Details ---")
+            lines.append("")
+            for ps in self.prospect_scores:
+                tier_str = "T%d" % ps.icp_tier if ps.icp_tier else "T?"
+                lines.append(
+                    "  %s  [%s]  depth=%d/10  sources=%d  people=%d  signals=%d" % (
+                        ps.name, tier_str, ps.research_depth,
+                        ps.source_count, ps.key_people_count, ps.signal_count,
+                    )
+                )
+
+        lines.append("")
+        lines.append("=" * 60)
+        return "\n".join(lines)
+
+
+# ═══════════════════════════════════════════════
+# Name matching (H2: tightened threshold)
+# ═══════════════════════════════════════════════
+
+FILLER_WORDS = {"and", "the", "of", "in", "for", "&", "-", "a", "an"}
+
+COMPANY_SUFFIXES = [
+    " ltd", " ltd.", " limited", " inc", " inc.", " incorporated",
+    " corp", " corp.", " corporation", " co", " co.",
+    " group", " holdings", " enterprises",
+    " & co", " & company", " llc", " lp",
+]
+
+
+def normalize_name(name):
+    """Normalize company name for comparison."""
+    name = name.lower().strip()
+    for suffix in COMPANY_SUFFIXES:
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+    return name.strip()
+
+
+def significant_words(name):
+    """Extract significant (non-filler) words from a company name."""
+    normalized = normalize_name(name)
+    words = set(normalized.replace("/", " ").replace(",", " ").replace("-", " ").split())
+    return words - FILLER_WORDS
+
+
+def find_best_match(agent_company, baseline_companies):
+    """
+    Find the best matching baseline company. H2: tightened matching.
+    Requires sequence similarity >= 0.85 OR exact containment of
+    significant name (not just any shared word like 'construction').
+    """
+    agent_name = agent_company.get("name", "")
+    n1 = normalize_name(agent_name)
+    w1 = significant_words(agent_name)
+
+    best_match = None
+    best_ratio = 0
+
+    for bc in baseline_companies:
+        bc_name = bc.get("name", "")
+        n2 = normalize_name(bc_name)
+
+        # Exact match after normalization
+        if n1 == n2:
+            return bc
+
+        # One fully contains the other (not just a shared word)
+        if len(n1) > 3 and len(n2) > 3:
+            if n1 in n2 or n2 in n1:
+                return bc
+
+        # Sequence similarity — require 0.85 (H2: was 0.6)
+        ratio = SequenceMatcher(None, n1, n2).ratio()
+
+        # Also require at least 2 significant words overlap
+        w2 = significant_words(bc_name)
+        shared = w1 & w2
+        significant_overlap = len(shared) >= 2
+
+        # Must pass BOTH thresholds
+        if ratio >= 0.85 and significant_overlap and ratio > best_ratio:
+            best_ratio = ratio
+            best_match = bc
+
+    return best_match
+
+
+# ═══════════════════════════════════════════════
+# Comparison functions
+# ═══════════════════════════════════════════════
+
+def compare_revenue(baseline, agent, tolerance=0.30):
+    """Compare revenue estimates. Returns None if either is missing."""
+    if baseline is None or agent is None:
+        return None
+    if baseline == 0:
+        return agent == 0
+    pct_diff = abs(agent - baseline) / baseline
+    return pct_diff <= tolerance
+
+
+def compare_ownership(baseline, agent):
+    """Compare ownership type classifications."""
+    if baseline is None or agent is None:
+        return None
+    return normalize_name(str(baseline)) == normalize_name(str(agent))
+
+
+def compare_industry(baseline, agent):
+    """Compare industry classifications using fuzzy matching."""
+    if baseline is None or agent is None:
+        return None
+    b = baseline.lower()
+    a = agent.lower()
+
+    if b == a:
+        return True
+
+    b_words = set(b.replace("/", " ").replace(",", " ").split()) - FILLER_WORDS
+    a_words = set(a.replace("/", " ").replace(",", " ").split()) - FILLER_WORDS
+
+    if not b_words or not a_words:
+        return False
+
+    overlap = len(b_words & a_words) / min(len(b_words), len(a_words))
+    return overlap >= 0.3
+
+
+def compare_succession_scores(baseline, agent):
+    """Compare succession scorecard dimensions. Returns delta per dimension."""
+    dimensions = [
+        "score_owner_age", "score_tenure", "score_nextgen_clarity",
+        "score_legacy_signals", "score_activity_trajectory",
+    ]
+    deltas = {}
+    for dim in dimensions:
+        b_val = baseline.get(dim)
+        a_val = agent.get(dim)
+        if b_val is not None and a_val is not None:
+            deltas[dim] = a_val - b_val
+        else:
+            deltas[dim] = None
+    return deltas
+
+
+# ═══════════════════════════════════════════════
+# Scoring functions
+# ═══════════════════════════════════════════════
+
+def score_company(agent_company, baseline_company, agent_sources=None):
+    """Score a single company comparison (rediscovery mode)."""
+    cs = CompanyScore(
+        name=agent_company.get("name", "unknown"),
+        baseline_name=baseline_company.get("name", "") if baseline_company else "",
+        matched=baseline_company is not None,
+    )
+
+    if baseline_company:
+        cs.revenue_baseline = baseline_company.get("revenue_estimate")
+        cs.revenue_agent = agent_company.get("revenue_estimate")
+        if cs.revenue_baseline is not None:
+            cs.revenue_baseline = float(cs.revenue_baseline)
+        if cs.revenue_agent is not None:
+            cs.revenue_agent = float(cs.revenue_agent)
+
+        cs.revenue_accurate = compare_revenue(cs.revenue_baseline, cs.revenue_agent)
+        cs.ownership_match = compare_ownership(
+            baseline_company.get("ownership_type"),
+            agent_company.get("ownership_type"),
+        )
+        cs.industry_match = compare_industry(
+            baseline_company.get("industry"),
+            agent_company.get("industry"),
+        )
+        cs.succession_deltas = compare_succession_scores(baseline_company, agent_company)
+
+    if agent_sources:
+        cs.source_count = len(agent_sources)
+
+    return cs
+
+
+def score_prospect(company, sources=None, key_people=None, signals=None, pipeline=None):
+    """Score a single company in prospecting mode."""
+    # Count populated fields for completeness
+    profile_fields = [
+        "name", "location", "province", "industry", "founded_year",
+        "website", "ownership_type", "revenue_estimate", "employee_count",
+        "score_owner_age", "score_tenure", "score_nextgen_clarity",
+        "score_legacy_signals", "score_activity_trajectory",
+    ]
+    populated = sum(1 for f in profile_fields if company.get(f) is not None)
+    completeness = populated / len(profile_fields)
+
+    rev = company.get("revenue_estimate")
+    if rev is not None:
+        rev = float(rev)
+
+    # Determine ICP tier from succession readiness and revenue
+    readiness = company.get("succession_readiness", "")
+    tier = None
+    if rev and rev >= 30 and rev <= 150 and readiness in ("High", "Very High"):
+        tier = 1
+    elif rev and ((15 <= rev < 30) or (150 < rev <= 300)):
+        tier = 2
+    elif rev and ((10 <= rev < 15) or rev > 300):
+        tier = 3
+    elif rev and rev >= 30:
+        tier = 2
+
+    return ProspectScore(
+        name=company.get("name", "unknown"),
+        has_revenue=rev is not None,
+        has_ownership_type=company.get("ownership_type") is not None,
+        has_industry=company.get("industry") is not None,
+        has_succession_scores=company.get("score_owner_age") is not None,
+        has_website=company.get("website") is not None,
+        revenue_in_range=10 <= rev <= 500 if rev else False,
+        icp_tier=tier,
+        source_count=len(sources) if sources else 0,
+        key_people_count=len(key_people) if key_people else 0,
+        signal_count=len(signals) if signals else 0,
+        has_pipeline_entry=pipeline is not None and len(pipeline) > 0,
+        completeness=completeness,
+    )


### PR DESCRIPTION
## Summary
- Built two Anthropic Managed Agents: **Province Prospector** (finds new companies matching ICP) and **Company Monitor** (weekly signal detection on existing pipeline)
- Added **Activity Feed** as the default dashboard view with URGENT/NOTABLE/ROUTINE signal grouping
- Added **Activity Timeline** in company detail for chronological signal history
- Added view-based **NEW badges**, **multiselect pipeline filter**, **password gate**, and **logout**
- Pipeline grew from 36 to **71 companies** across all 4 Atlantic provinces

## Test plan
- [ ] Verify password gate blocks access (password: `MorrisonWins!`)
- [ ] Verify Activity Feed loads as default view with signals grouped by urgency
- [ ] Verify clicking a signal navigates to company detail and scrolls to Activity Timeline
- [ ] Verify "Back to Activity Feed" button returns to feed
- [ ] Verify NEW badges disappear after viewing a company
- [ ] Verify "Display new only" filter works in sidebar
- [ ] Verify Pipeline Stage multiselect allows multiple selections
- [ ] Verify logout clears session and shows login screen
- [ ] Run prospector: `cd managed-agent && python run_session.py NB`
- [ ] Run monitor: `cd managed-agent && python monitor_run.py --province NB`

🤖 Generated with [Claude Code](https://claude.com/claude-code)