### PR TITLE
feat(dashboard): per-signal feedback on activity feed

### DIFF
--- a/idea_cards/index.html
+++ b/idea_cards/index.html
@@ -973,6 +973,83 @@
 
     .activity-source:hover { text-decoration: underline; }
 
+    .activity-item-footer {
+      display: flex;
+      align-items: center;
+      margin-top: 8px;
+      gap: 12px;
+    }
+
+    .activity-feedback {
+      display: inline-flex;
+      gap: 6px;
+      margin-left: auto;
+    }
+
+    .thumb {
+      width: 28px;
+      height: 28px;
+      padding: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      border: 1px solid var(--border-subtle);
+      border-radius: 6px;
+      color: var(--text-muted);
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    .thumb:hover {
+      border-color: var(--border-medium);
+      color: var(--text-secondary);
+    }
+
+    .thumb svg { display: block; }
+
+    .thumb-up.thumb-active {
+      color: #ffffff;
+      background: var(--accent-emerald);
+      border-color: var(--accent-emerald);
+    }
+
+    .thumb-down.thumb-active {
+      color: #ffffff;
+      background: var(--accent-rose);
+      border-color: var(--accent-rose);
+    }
+
+    .activity-comment {
+      margin-top: 8px;
+      display: none;
+    }
+
+    .activity-item.has-vote .activity-comment {
+      display: block;
+    }
+
+    .comment-input {
+      width: 100%;
+      padding: 6px 10px;
+      font-size: 12px;
+      font-family: inherit;
+      color: var(--text-primary);
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border-subtle);
+      border-radius: 6px;
+      outline: none;
+      transition: border-color 0.15s ease;
+    }
+
+    .comment-input:focus {
+      border-color: var(--accent-blue);
+    }
+
+    .comment-input::placeholder {
+      color: var(--text-muted);
+    }
+
     .activity-empty {
       text-align: center;
       padding: 60px 24px;
@@ -1518,14 +1595,29 @@
 
       try {
         var thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-        var { data, error } = await supabase
-          .from('signals')
-          .select('*, companies(id, name, province, succession_composite)')
-          .gte('created_at', thirtyDaysAgo)
-          .order('created_at', { ascending: false });
+        var [signalsRes, feedbackRes] = await Promise.all([
+          supabase
+            .from('signals')
+            .select('*, companies(id, name, province, succession_composite)')
+            .gte('created_at', thirtyDaysAgo)
+            .order('created_at', { ascending: false }),
+          supabase
+            .from('signal_feedback')
+            .select('signal_id, vote, comment'),
+        ]);
 
-        if (error) throw error;
-        activitySignals = data || [];
+        if (signalsRes.error) throw signalsRes.error;
+        if (feedbackRes.error) throw feedbackRes.error;
+
+        var feedbackBySignalId = {};
+        (feedbackRes.data || []).forEach(function(f) {
+          feedbackBySignalId[f.signal_id] = { vote: f.vote, comment: f.comment };
+        });
+
+        activitySignals = (signalsRes.data || []).map(function(s) {
+          s.feedback = feedbackBySignalId[s.id] || null;
+          return s;
+        });
         renderActivityFeed(activitySignals);
       } catch (err) {
         feed.innerHTML = '<div class="activity-empty">Error loading signals: ' + err.message + '</div>';
@@ -1611,6 +1703,72 @@
       feed.innerHTML = html;
     }
 
+    async function handleSignalVote(signalId, vote, btnEl) {
+      var signal = (activitySignals || []).find(function(s) { return s.id === signalId; });
+      var currentVote = signal && signal.feedback ? signal.feedback.vote : null;
+      var itemEl = btnEl.closest('.activity-item');
+      var upEl = itemEl.querySelector('.thumb-up');
+      var downEl = itemEl.querySelector('.thumb-down');
+
+      try {
+        if (currentVote === vote) {
+          // Undo: delete the feedback row
+          var { error } = await supabase
+            .from('signal_feedback')
+            .delete()
+            .eq('signal_id', signalId);
+          if (error) throw error;
+
+          if (signal) signal.feedback = null;
+          upEl.classList.remove('thumb-active');
+          downEl.classList.remove('thumb-active');
+          itemEl.classList.remove('has-vote');
+          var input = itemEl.querySelector('.comment-input');
+          if (input) input.value = '';
+        } else {
+          // Upsert new vote; preserve comment on switch
+          var existingComment = signal && signal.feedback ? signal.feedback.comment : null;
+          var { error } = await supabase
+            .from('signal_feedback')
+            .upsert({
+              signal_id: signalId,
+              vote: vote,
+              comment: existingComment,
+              updated_at: new Date().toISOString(),
+            }, { onConflict: 'signal_id' });
+          if (error) throw error;
+
+          if (signal) signal.feedback = { vote: vote, comment: existingComment };
+          upEl.classList.toggle('thumb-active', vote === 'up');
+          downEl.classList.toggle('thumb-active', vote === 'down');
+          itemEl.classList.add('has-vote');
+        }
+      } catch (err) {
+        console.error('Error saving vote:', err);
+        alert('Could not save feedback: ' + err.message);
+      }
+    }
+
+    async function handleCommentBlur(signalId, commentText) {
+      var signal = (activitySignals || []).find(function(s) { return s.id === signalId; });
+      // Only persist comments when a vote exists — avoids orphan rows.
+      if (!signal || !signal.feedback) return;
+      var trimmed = commentText.trim();
+      var nextComment = trimmed.length > 0 ? trimmed : null;
+      if (nextComment === signal.feedback.comment) return;
+
+      try {
+        var { error } = await supabase
+          .from('signal_feedback')
+          .update({ comment: nextComment, updated_at: new Date().toISOString() })
+          .eq('signal_id', signalId);
+        if (error) throw error;
+        signal.feedback.comment = nextComment;
+      } catch (err) {
+        console.error('Error saving comment:', err);
+      }
+    }
+
     function renderActivityItem(signal) {
       var companyName = signal.companies ? signal.companies.name : 'Unknown';
       var companyId = signal.companies ? signal.companies.id : '';
@@ -1618,8 +1776,18 @@
       var unseen = !isSeen(SEEN_SIGNALS_KEY, signal.id);
       var signalType = signal.signal_type || '';
       var category = (signal.signal_category || '').replace(/_/g, ' ');
+      var feedback = signal.feedback || null;
+      var voteClass = feedback ? ' has-vote' : '';
+      var upActive = feedback && feedback.vote === 'up' ? ' thumb-active' : '';
+      var downActive = feedback && feedback.vote === 'down' ? ' thumb-active' : '';
+      var commentValue = feedback && feedback.comment
+        ? String(feedback.comment).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        : '';
 
-      return '<div class="activity-item" onclick="selectCompany(\'' + companyId + '\', true)">'
+      var thumbUpSvg = '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M2 21h4V9H2v12zm20-11.5c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L13.17 1 6.59 7.59C6.22 7.95 6 8.45 6 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73V9.5z"/></svg>';
+      var thumbDownSvg = '<svg viewBox="0 0 24 24" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M22 3h-4v12h4V3zM2 14.5c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L10.83 23l6.59-6.59c.37-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2H7c-.83 0-1.54.5-1.84 1.22L2.14 11.27c-.09.23-.14.47-.14.73v2.5z"/></svg>';
+
+      return '<div class="activity-item' + voteClass + '" data-signal-id="' + signal.id + '" onclick="selectCompany(\'' + companyId + '\', true)">'
         + '<div class="activity-type-indicator ' + signalType + '"></div>'
         + '<div class="activity-item-body">'
         + '<div class="activity-item-top">'
@@ -1630,7 +1798,20 @@
         + '<span class="activity-time">' + timeAgo(signal.created_at) + '</span>'
         + '</div>'
         + '<div class="activity-desc">' + (signal.description || category) + '</div>'
-        + (signal.source_url ? '<a class="activity-source" href="' + signal.source_url + '" target="_blank" onclick="event.stopPropagation();">View source</a>' : '')
+        + '<div class="activity-item-footer">'
+        + (signal.source_url ? '<a class="activity-source" href="' + signal.source_url + '" target="_blank" onclick="event.stopPropagation();">View source</a>' : '<span></span>')
+        + '<div class="activity-feedback">'
+        + '<button type="button" class="thumb thumb-up' + upActive + '" aria-label="Helpful" title="Helpful" onclick="event.stopPropagation(); handleSignalVote(\'' + signal.id + '\', \'up\', this);">' + thumbUpSvg + '</button>'
+        + '<button type="button" class="thumb thumb-down' + downActive + '" aria-label="Not useful" title="Not useful" onclick="event.stopPropagation(); handleSignalVote(\'' + signal.id + '\', \'down\', this);">' + thumbDownSvg + '</button>'
+        + '</div>'
+        + '</div>'
+        + '<div class="activity-comment">'
+        + '<input type="text" class="comment-input" data-signal-id="' + signal.id + '"'
+        + ' placeholder="Why? (optional — helps tune the agents)"'
+        + ' value="' + commentValue + '"'
+        + ' onclick="event.stopPropagation();"'
+        + ' onblur="handleCommentBlur(\'' + signal.id + '\', this.value);">'
+        + '</div>'
         + '</div></div>';
     }
 

--- a/idea_cards/types/database.types.ts
+++ b/idea_cards/types/database.types.ts
@@ -16,17 +16,32 @@ export type Database = {
     Tables: {
       companies: {
         Row: {
+          company_description: string | null
+          company_history: string | null
+          competitive_position: string | null
           confidence: string | null
           created_at: string | null
+          deal_activity: string | null
           employee_count: number | null
+          executive_summary: string | null
+          financial_highlights: Json | null
           founded_year: number | null
+          generated_by_model: string | null
+          geographies: string[] | null
           id: string
           industry: string | null
+          industry_memberships: string | null
+          industry_tailwinds: string | null
+          last_monitored_at: string | null
           legal_name: string | null
           location: string
+          major_projects: string | null
           markdown_content: string | null
+          markets_customers: string | null
+          model_metadata: Json | null
           name: string
           ownership_type: string | null
+          products_services: string | null
           province: string
           research_date: string | null
           revenue_estimate: number | null
@@ -35,23 +50,40 @@ export type Database = {
           score_nextgen_clarity: number | null
           score_owner_age: number | null
           score_tenure: number | null
+          stock_exchange: string | null
           succession_composite: number | null
           succession_readiness: string | null
+          ticker_symbol: string | null
           updated_at: string | null
           website: string | null
         }
         Insert: {
+          company_description?: string | null
+          company_history?: string | null
+          competitive_position?: string | null
           confidence?: string | null
           created_at?: string | null
+          deal_activity?: string | null
           employee_count?: number | null
+          executive_summary?: string | null
+          financial_highlights?: Json | null
           founded_year?: number | null
+          generated_by_model?: string | null
+          geographies?: string[] | null
           id?: string
           industry?: string | null
+          industry_memberships?: string | null
+          industry_tailwinds?: string | null
+          last_monitored_at?: string | null
           legal_name?: string | null
           location: string
+          major_projects?: string | null
           markdown_content?: string | null
+          markets_customers?: string | null
+          model_metadata?: Json | null
           name: string
           ownership_type?: string | null
+          products_services?: string | null
           province: string
           research_date?: string | null
           revenue_estimate?: number | null
@@ -60,23 +92,40 @@ export type Database = {
           score_nextgen_clarity?: number | null
           score_owner_age?: number | null
           score_tenure?: number | null
+          stock_exchange?: string | null
           succession_composite?: number | null
           succession_readiness?: string | null
+          ticker_symbol?: string | null
           updated_at?: string | null
           website?: string | null
         }
         Update: {
+          company_description?: string | null
+          company_history?: string | null
+          competitive_position?: string | null
           confidence?: string | null
           created_at?: string | null
+          deal_activity?: string | null
           employee_count?: number | null
+          executive_summary?: string | null
+          financial_highlights?: Json | null
           founded_year?: number | null
+          generated_by_model?: string | null
+          geographies?: string[] | null
           id?: string
           industry?: string | null
+          industry_memberships?: string | null
+          industry_tailwinds?: string | null
+          last_monitored_at?: string | null
           legal_name?: string | null
           location?: string
+          major_projects?: string | null
           markdown_content?: string | null
+          markets_customers?: string | null
+          model_metadata?: Json | null
           name?: string
           ownership_type?: string | null
+          products_services?: string | null
           province?: string
           research_date?: string | null
           revenue_estimate?: number | null
@@ -85,8 +134,10 @@ export type Database = {
           score_nextgen_clarity?: number | null
           score_owner_age?: number | null
           score_tenure?: number | null
+          stock_exchange?: string | null
           succession_composite?: number | null
           succession_readiness?: string | null
+          ticker_symbol?: string | null
           updated_at?: string | null
           website?: string | null
         }
@@ -97,30 +148,39 @@ export type Database = {
           board_seat: boolean | null
           company_id: string | null
           created_at: string | null
+          generated_by_model: string | null
           id: string
           investment_amount: number | null
           investment_date: string | null
           investor_id: string | null
+          model_metadata: Json | null
+          round_type: string | null
           source_url: string
         }
         Insert: {
           board_seat?: boolean | null
           company_id?: string | null
           created_at?: string | null
+          generated_by_model?: string | null
           id?: string
           investment_amount?: number | null
           investment_date?: string | null
           investor_id?: string | null
+          model_metadata?: Json | null
+          round_type?: string | null
           source_url: string
         }
         Update: {
           board_seat?: boolean | null
           company_id?: string | null
           created_at?: string | null
+          generated_by_model?: string | null
           id?: string
           investment_amount?: number | null
           investment_date?: string | null
           investor_id?: string | null
+          model_metadata?: Json | null
+          round_type?: string | null
           source_url?: string
         }
         Relationships: [
@@ -147,14 +207,76 @@ export type Database = {
           },
         ]
       }
+      comparable_transactions: {
+        Row: {
+          acquirer_name: string | null
+          company_id: string
+          created_at: string | null
+          deal_value: number | null
+          description: string | null
+          generated_by_model: string | null
+          id: string
+          model_metadata: Json | null
+          multiple: string | null
+          source_url: string | null
+          target_name: string
+          transaction_date: string | null
+        }
+        Insert: {
+          acquirer_name?: string | null
+          company_id: string
+          created_at?: string | null
+          deal_value?: number | null
+          description?: string | null
+          generated_by_model?: string | null
+          id?: string
+          model_metadata?: Json | null
+          multiple?: string | null
+          source_url?: string | null
+          target_name: string
+          transaction_date?: string | null
+        }
+        Update: {
+          acquirer_name?: string | null
+          company_id?: string
+          created_at?: string | null
+          deal_value?: number | null
+          description?: string | null
+          generated_by_model?: string | null
+          id?: string
+          model_metadata?: Json | null
+          multiple?: string | null
+          source_url?: string | null
+          target_name?: string
+          transaction_date?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "comparable_transactions_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "comparable_transactions_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "company_dashboard_view"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       connections: {
         Row: {
           company_id: string | null
           connection_detail: string
           connection_type: string | null
           created_at: string | null
+          generated_by_model: string | null
           id: string
           introducer_relationship: string | null
+          model_metadata: Json | null
           potential_introducer: string | null
           source_url: string
         }
@@ -163,8 +285,10 @@ export type Database = {
           connection_detail: string
           connection_type?: string | null
           created_at?: string | null
+          generated_by_model?: string | null
           id?: string
           introducer_relationship?: string | null
+          model_metadata?: Json | null
           potential_introducer?: string | null
           source_url: string
         }
@@ -173,8 +297,10 @@ export type Database = {
           connection_detail?: string
           connection_type?: string | null
           created_at?: string | null
+          generated_by_model?: string | null
           id?: string
           introducer_relationship?: string | null
+          model_metadata?: Json | null
           potential_introducer?: string | null
           source_url?: string
         }
@@ -198,9 +324,11 @@ export type Database = {
       investors: {
         Row: {
           created_at: string | null
+          generated_by_model: string | null
           geographic_focus: string[] | null
           id: string
           investor_type: string | null
+          model_metadata: Json | null
           name: string
           sectors: string[] | null
           source_url: string
@@ -208,9 +336,11 @@ export type Database = {
         }
         Insert: {
           created_at?: string | null
+          generated_by_model?: string | null
           geographic_focus?: string[] | null
           id?: string
           investor_type?: string | null
+          model_metadata?: Json | null
           name: string
           sectors?: string[] | null
           source_url: string
@@ -218,9 +348,11 @@ export type Database = {
         }
         Update: {
           created_at?: string | null
+          generated_by_model?: string | null
           geographic_focus?: string[] | null
           id?: string
           investor_type?: string | null
+          model_metadata?: Json | null
           name?: string
           sectors?: string[] | null
           source_url?: string
@@ -230,42 +362,69 @@ export type Database = {
       }
       key_people: {
         Row: {
+          affiliation: string | null
           age_estimate: number | null
           company_id: string | null
+          conversation_starters: string | null
           created_at: string | null
+          generated_by_model: string | null
           id: string
+          linkedin_about: string | null
+          linkedin_headline: string | null
+          linkedin_scraped_at: string | null
+          linkedin_themes: string | null
           linkedin_url: string | null
+          model_metadata: Json | null
           name: string
           notes: string | null
           ownership_percentage: number | null
+          person_type: string | null
           role: string | null
           source_url: string
           tenure_years: number | null
           title: string | null
         }
         Insert: {
+          affiliation?: string | null
           age_estimate?: number | null
           company_id?: string | null
+          conversation_starters?: string | null
           created_at?: string | null
+          generated_by_model?: string | null
           id?: string
+          linkedin_about?: string | null
+          linkedin_headline?: string | null
+          linkedin_scraped_at?: string | null
+          linkedin_themes?: string | null
           linkedin_url?: string | null
+          model_metadata?: Json | null
           name: string
           notes?: string | null
           ownership_percentage?: number | null
+          person_type?: string | null
           role?: string | null
           source_url: string
           tenure_years?: number | null
           title?: string | null
         }
         Update: {
+          affiliation?: string | null
           age_estimate?: number | null
           company_id?: string | null
+          conversation_starters?: string | null
           created_at?: string | null
+          generated_by_model?: string | null
           id?: string
+          linkedin_about?: string | null
+          linkedin_headline?: string | null
+          linkedin_scraped_at?: string | null
+          linkedin_themes?: string | null
           linkedin_url?: string | null
+          model_metadata?: Json | null
           name?: string
           notes?: string | null
           ownership_percentage?: number | null
+          person_type?: string | null
           role?: string | null
           source_url?: string
           tenure_years?: number | null
@@ -281,6 +440,63 @@ export type Database = {
           },
           {
             foreignKeyName: "key_people_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "company_dashboard_view"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      ma_transactions: {
+        Row: {
+          company_id: string
+          counterparty: string | null
+          created_at: string | null
+          deal_value: number | null
+          description: string
+          generated_by_model: string | null
+          id: string
+          model_metadata: Json | null
+          source_url: string | null
+          transaction_date: string | null
+          transaction_type: string | null
+        }
+        Insert: {
+          company_id: string
+          counterparty?: string | null
+          created_at?: string | null
+          deal_value?: number | null
+          description: string
+          generated_by_model?: string | null
+          id?: string
+          model_metadata?: Json | null
+          source_url?: string | null
+          transaction_date?: string | null
+          transaction_type?: string | null
+        }
+        Update: {
+          company_id?: string
+          counterparty?: string | null
+          created_at?: string | null
+          deal_value?: number | null
+          description?: string
+          generated_by_model?: string | null
+          id?: string
+          model_metadata?: Json | null
+          source_url?: string | null
+          transaction_date?: string | null
+          transaction_type?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "ma_transactions_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "ma_transactions_company_id_fkey"
             columns: ["company_id"]
             isOneToOne: false
             referencedRelation: "company_dashboard_view"
@@ -348,7 +564,9 @@ export type Database = {
           acquirer_type: string | null
           company_id: string | null
           created_at: string | null
+          generated_by_model: string | null
           id: string
+          model_metadata: Json | null
           rationale: string | null
           recent_deals: string | null
           source_url: string
@@ -358,7 +576,9 @@ export type Database = {
           acquirer_type?: string | null
           company_id?: string | null
           created_at?: string | null
+          generated_by_model?: string | null
           id?: string
+          model_metadata?: Json | null
           rationale?: string | null
           recent_deals?: string | null
           source_url: string
@@ -368,7 +588,9 @@ export type Database = {
           acquirer_type?: string | null
           company_id?: string | null
           created_at?: string | null
+          generated_by_model?: string | null
           id?: string
+          model_metadata?: Json | null
           rationale?: string | null
           recent_deals?: string | null
           source_url?: string
@@ -390,6 +612,57 @@ export type Database = {
           },
         ]
       }
+      products: {
+        Row: {
+          company_id: string
+          created_at: string | null
+          description: string | null
+          generated_by_model: string | null
+          id: string
+          model_metadata: Json | null
+          name: string
+          product_type: string | null
+          source_url: string | null
+        }
+        Insert: {
+          company_id: string
+          created_at?: string | null
+          description?: string | null
+          generated_by_model?: string | null
+          id?: string
+          model_metadata?: Json | null
+          name: string
+          product_type?: string | null
+          source_url?: string | null
+        }
+        Update: {
+          company_id?: string
+          created_at?: string | null
+          description?: string | null
+          generated_by_model?: string | null
+          id?: string
+          model_metadata?: Json | null
+          name?: string
+          product_type?: string | null
+          source_url?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "products_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "products_company_id_fkey"
+            columns: ["company_id"]
+            isOneToOne: false
+            referencedRelation: "company_dashboard_view"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       research_sources: {
         Row: {
           access_date: string | null
@@ -397,7 +670,9 @@ export type Database = {
           confidence: string | null
           created_at: string | null
           data_points: string[] | null
+          generated_by_model: string | null
           id: string
+          model_metadata: Json | null
           source_name: string
           source_type: string | null
           source_url: string
@@ -408,7 +683,9 @@ export type Database = {
           confidence?: string | null
           created_at?: string | null
           data_points?: string[] | null
+          generated_by_model?: string | null
           id?: string
+          model_metadata?: Json | null
           source_name: string
           source_type?: string | null
           source_url: string
@@ -419,7 +696,9 @@ export type Database = {
           confidence?: string | null
           created_at?: string | null
           data_points?: string[] | null
+          generated_by_model?: string | null
           id?: string
+          model_metadata?: Json | null
           source_name?: string
           source_type?: string | null
           source_url?: string
@@ -441,13 +720,50 @@ export type Database = {
           },
         ]
       }
+      signal_feedback: {
+        Row: {
+          comment: string | null
+          created_at: string
+          id: string
+          signal_id: string
+          updated_at: string
+          vote: string
+        }
+        Insert: {
+          comment?: string | null
+          created_at?: string
+          id?: string
+          signal_id: string
+          updated_at?: string
+          vote: string
+        }
+        Update: {
+          comment?: string | null
+          created_at?: string
+          id?: string
+          signal_id?: string
+          updated_at?: string
+          vote?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "signal_feedback_signal_id_fkey"
+            columns: ["signal_id"]
+            isOneToOne: true
+            referencedRelation: "signals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       signals: {
         Row: {
           company_id: string | null
           confidence: string | null
           created_at: string | null
           description: string
+          generated_by_model: string | null
           id: string
+          model_metadata: Json | null
           signal_category: string | null
           signal_date: string | null
           signal_type: string | null
@@ -458,7 +774,9 @@ export type Database = {
           confidence?: string | null
           created_at?: string | null
           description: string
+          generated_by_model?: string | null
           id?: string
+          model_metadata?: Json | null
           signal_category?: string | null
           signal_date?: string | null
           signal_type?: string | null
@@ -469,7 +787,9 @@ export type Database = {
           confidence?: string | null
           created_at?: string | null
           description?: string
+          generated_by_model?: string | null
           id?: string
+          model_metadata?: Json | null
           signal_category?: string | null
           signal_date?: string | null
           signal_type?: string | null
@@ -550,20 +870,32 @@ export type Database = {
           accuracy_score: number | null
           acquirer_count: number | null
           actionability_score: number | null
+          company_description: string | null
+          company_history: string | null
+          competitive_position: string | null
           confidence: string | null
           created_at: string | null
+          deal_activity: string | null
           employee_count: number | null
+          executive_summary: string | null
           feedback_notes: string | null
           founded_year: number | null
           id: string | null
           industry: string | null
+          industry_memberships: string | null
           legal_name: string | null
           location: string | null
+          major_projects: string | null
           markdown_content: string | null
+          markets_customers: string | null
           name: string | null
           novelty_score: number | null
           ownership_type: string | null
           people_count: number | null
+          pipeline_client_type: string | null
+          pipeline_priority: number | null
+          pipeline_stage: string | null
+          products_services: string | null
           province: string | null
           research_date: string | null
           revenue_estimate: number | null
@@ -733,6 +1065,8 @@ export type CompanyInvestor = Database['public']['Tables']['company_investors'][
 export type CompanyInvestorInsert = Database['public']['Tables']['company_investors']['Insert']
 export type Signal = Database['public']['Tables']['signals']['Row']
 export type SignalInsert = Database['public']['Tables']['signals']['Insert']
+export type SignalFeedback = Database['public']['Tables']['signal_feedback']['Row']
+export type SignalFeedbackInsert = Database['public']['Tables']['signal_feedback']['Insert']
 export type Connection = Database['public']['Tables']['connections']['Row']
 export type ConnectionInsert = Database['public']['Tables']['connections']['Insert']
 export type Pipeline = Database['public']['Tables']['pipeline']['Row']
@@ -740,6 +1074,7 @@ export type PipelineInsert = Database['public']['Tables']['pipeline']['Insert']
 
 // Signal type enums for type safety
 export type SignalType = 'sell_side' | 'buy_side' | 'growth' | 'leadership' | 'financial' | 'strategic'
+export type SignalVote = 'up' | 'down'
 export type ConnectionType = 'board' | 'conference' | 'philanthropy' | 'advisor' | 'alumni' | 'investor' | 'personal' | 'other'
 export type PipelineStage = 'prospect' | 'researching' | 'outreach' | 'engaged' | 'active_deal' | 'closed' | 'passed'
 export type ClientType = 'sell_side' | 'buy_side' | 'growth_capital'


### PR DESCRIPTION
## Summary

Adds thumbs-up / thumbs-down + optional comment on each card in the Activity Feed, persisted to Supabase. Gives Ken a one-click way to label individual signals as useful or noisy, and sets up the capture side of a future agent-tuning loop (Stage 2) where downvote comments get fed back into the Province Prospector and Company Monitor prompts.

Today, the only feedback mechanism is the heavyweight "Rate This Idea Card" form on the company detail panel, which rates the whole profile. That's too coarse to tell the agents which specific *signals* were worth surfacing. This change captures signal-level labels.

## What changed

- **New `signal_feedback` table** — `signal_id` FK (unique, cascade delete), `vote` text ('up'|'down'), optional `comment`, timestamps, indexed `(vote, created_at desc)` for the future summarizer. Anon CRUD grants match the existing `user_feedback` pattern.
- **Bottom-right thumb controls** on every activity card — muted outline by default, fills emerald (up) or rose (down) when active. Click active thumb again to undo.
- **Inline comment input** slides in below the thumbs after voting. Placeholder: *"Why? (optional — helps tune the agents)"*. Auto-saves on blur. No-op when no vote exists, so typing without voting never creates an orphan row.
- **`loadActivityFeed()`** now fetches signals + feedback in parallel via `Promise.all` and hydrates each signal with its existing vote/comment so state is restored on first paint.
- **Regenerated `database.types.ts`** with `SignalFeedback`, `SignalFeedbackInsert`, and `SignalVote` convenience exports.

## Why it's designed this way

- Separate table (not columns on `signals`) keeps agent output immutable and makes the feedback an overlay — easier to reason about for a training loop.
- `unique(signal_id)` enforces single-vote semantics for this POC and makes upsert trivial. Adding `user_identifier` later is a non-breaking additive change.
- No RLS — matches the rest of the anon-key dashboard. Not introducing a new security model mid-POC.

## Testing

Verified end-to-end against Supabase in a local browser with Claude-in-Chrome:

- [x] Thumbs-up on Crosby Foods → emerald fill, row written with `vote='up'`
- [x] Typed comment + Tab blur → `comment` column updated
- [x] Thumbs-down on CKF Inc → rose fill, separate row written
- [x] Page reload → both cards restored correct filled state + comment text from DB
- [x] Click active thumbs-up again → row deleted, both thumbs return to outline, comment input hides
- [x] Existing company "Rate This Idea Card" form untouched

Test rows cleaned from the DB before pushing.

## Test plan

- [ ] Deploy to Netlify and confirm feature works against production Supabase
- [ ] Cast a few real votes on live signals so the Stage-2 summarizer work has data to chew on

🤖 Generated with [Claude Code](https://claude.com/claude-code)